### PR TITLE
add versioned tests that skip middle version + introduce incompatible change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Instructions for dropshot-api-manager
+
+## General instructions
+
+* Always use `cargo nextest run` to run tests. Never use `cargo test`.
+* Wrap comments to 80 characters.
+* Always end comments with a period.


### PR DESCRIPTION
Also fix a bug + add a test that if you delete a symlink, it is recreated to the expected location (which is the blessed hash, not the generated hash). Tricky!
