### PR TITLE
make api_versions generate a latest_version function

### DIFF
--- a/crates/dropshot-api-manager/README.md
+++ b/crates/dropshot-api-manager/README.md
@@ -143,7 +143,12 @@ api_versions!([
 **For both lockstep and versioned APIs:** once the API crate is defined, update the OpenAPI manager to manage the new OpenAPI document(s). Within this directory:
 
 1. In your repository's integration point's `Cargo.toml`, add a dependency on the API crate.
-2. Add the crate to the list of APIs managed by the OpenAPI manager. For versioned APIs, the `api_versions` macro defines a `supported_versions()` function, which you'll need to use
+2. Add the crate to the list of APIs managed by the OpenAPI manager. For versioned APIs, the `api_versions` macro defines a `supported_versions()` function, which you'll need to use.
+
+> [!NOTE]
+> The `api_versions!` macro also generates a `latest_version` function which returns the latest version (the first version on the list).
+>
+> When creating the server, you must configure a [`version_policy`](https://docs.rs/dropshot/latest/dropshot/struct.ServerBuilder.html#method.version_policy) to indicate that the API is versioned. If you use the [`ClientSpecifiesVersionInHeader`](https://docs.rs/dropshot/latest/dropshot/struct.ClientSpecifiesVersionInHeader.html) policy, then set the `max_version` to the output of `latest_version()`.
 
 To ensure everything works well, run `cargo openapi generate`. Your OpenAPI document should be generated on disk and listed in the output.
 

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -17,6 +17,12 @@ fn test_versioned_generate_basic() -> Result<()> {
     let env = TestEnvironment::new()?;
     let apis = versioned_health_apis()?;
 
+    // Check that latest_version exists.
+    assert_eq!(
+        versioned_health::latest_version(),
+        semver::Version::new(3, 0, 0),
+    );
+
     // Initially, no documents should exist.
     assert!(
         !env.versioned_local_document_exists("versioned-health", "1.0.0")


### PR DESCRIPTION
Make the `api_versions!` macro generate a `latest_version` function that produces the latest version. This makes it possible to add new versions without having to updating `ServerBuilder` callsites.
