### PR TITLE
[1/n] adapt to drift 0.2.0 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "drift"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cc7f4e6337c9c0d0402e2dccaeaea63fc38467a3e5ab3f465372dafce2cd89"
+checksum = "a453bee38ca50a50f5b9dd2a3802e6972020bbff0f0040701b28f002a2490d27"
 dependencies = [
  "anyhow",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ camino-tempfile-ext = "0.3.3"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = "4.5"
 debug-ignore = "1.0.5"
-drift = "0.1.3"
+drift = "0.2.0"
 dropshot = "0.17.0"
 dropshot-api-manager = { path = "crates/dropshot-api-manager", version = "0.7.1" }
 dropshot-api-manager-types = { path = "crates/dropshot-api-manager-types", version = "0.7.1" }

--- a/crates/dropshot-api-manager/src/compatibility/detect.rs
+++ b/crates/dropshot-api-manager/src/compatibility/detect.rs
@@ -2,7 +2,7 @@
 
 //! Determine if one OpenAPI document is a subset of another
 
-use drift::{Change, ChangeClass};
+use drift::{Change, ChangeClass, ChangeInfo};
 use std::{collections::BTreeMap, fmt};
 
 /// A compatibility error between two OpenAPI documents, indexed by the blessed
@@ -52,11 +52,10 @@ impl fmt::Display for ApiCompatIssue {
         }
 
         if self.data.changes.len() == 1 {
-            let Change {
+            let ChangeInfo {
                 message,
-                old_path: _,
-                new_path: _,
-                comparison: _,
+                old_subpath: _,
+                new_subpath: _,
                 class,
                 details: _,
             } = &self.data.changes[0];
@@ -64,11 +63,10 @@ impl fmt::Display for ApiCompatIssue {
         } else {
             writeln!(f)?;
             for error in &self.data.changes {
-                let Change {
+                let ChangeInfo {
                     message,
-                    old_path: _,
-                    new_path: _,
-                    comparison: _,
+                    old_subpath: _,
+                    new_subpath: _,
                     class,
                     details: _,
                 } = error;
@@ -89,7 +87,7 @@ impl fmt::Display for ApiCompatIssue {
 struct CompatIssueData {
     blessed_value: Option<serde_json::Value>,
     generated_value: Option<serde_json::Value>,
-    changes: Vec<Change>,
+    changes: Vec<ChangeInfo>,
 }
 
 impl CompatIssueData {
@@ -343,39 +341,61 @@ pub fn api_compatible(
     normalize_old_websocket_responses(&mut blessed, generated);
 
     let changes = drift::compare(&blessed, generated)?;
-    let changes = changes
+
+    // drift 0.2.0 groups multiple paths and multiple inner changes under a
+    // single `Change`. Flatten back to (path, info) pairs and aggregate by
+    // (blessed_pointer, generated_pointer) to preserve the existing
+    // grouping and rendering.
+    let aggregated = changes
         .into_iter()
-        .filter_map(|change| match change.class {
-            ChangeClass::BackwardIncompatible
-            | ChangeClass::ForwardIncompatible
-            | ChangeClass::Incompatible
-            | ChangeClass::Unhandled => Some(change),
-            ChangeClass::Trivial => None,
+        .flat_map(|Change { paths, changes: change_infos }| {
+            // Filter trivial here so an entry whose only inner changes are
+            // trivial doesn't create empty groups.
+            let non_trivial: Vec<ChangeInfo> = change_infos
+                .into_iter()
+                .filter(|info| match info.class {
+                    ChangeClass::BackwardIncompatible
+                    | ChangeClass::ForwardIncompatible
+                    | ChangeClass::Incompatible
+                    | ChangeClass::Unhandled => true,
+                    ChangeClass::Trivial => false,
+                })
+                .collect();
+            paths
+                .into_iter()
+                .flat_map(move |path| {
+                    let blessed_pointer =
+                        path.old.iter().next().unwrap_or("").to_owned();
+                    let generated_pointer =
+                        path.new.iter().next().unwrap_or("").to_owned();
+                    non_trivial.clone().into_iter().map(move |info| {
+                        (
+                            blessed_pointer.clone(),
+                            generated_pointer.clone(),
+                            info,
+                        )
+                    })
+                })
+                .collect::<Vec<_>>()
         })
         .fold(
-            // BTreeMap of (blessed_pointer, generated_pointer) => data
             BTreeMap::<(String, String), CompatIssueData>::new(),
-            |mut acc, change| {
-                let blessed_pointer = change.old_path.iter().next().unwrap();
-                let generated_pointer = change.new_path.iter().next().unwrap();
-                acc.entry((
-                    blessed_pointer.to_owned(),
-                    generated_pointer.to_owned(),
-                ))
-                .or_insert_with(|| {
-                    CompatIssueData::new(
-                        &blessed,
-                        blessed_pointer,
-                        generated,
-                        generated_pointer,
-                    )
-                })
-                .changes
-                .push(change);
+            |mut acc, (blessed_pointer, generated_pointer, info)| {
+                acc.entry((blessed_pointer.clone(), generated_pointer.clone()))
+                    .or_insert_with(|| {
+                        CompatIssueData::new(
+                            &blessed,
+                            &blessed_pointer,
+                            generated,
+                            &generated_pointer,
+                        )
+                    })
+                    .changes
+                    .push(info);
                 acc
             },
         );
-    Ok(changes
+    Ok(aggregated
         .into_iter()
         .map(|((blessed_pointer, generated_pointer), data)| ApiCompatIssue {
             blessed_pointer,

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -1859,7 +1859,15 @@ fn test_blessed_ws_old_format_fails_without_normalizer() -> Result<()> {
     let changes = drift::compare(&old_spec, &new_spec)?;
     let non_trivial: Vec<_> = changes
         .iter()
-        .filter(|c| !matches!(c.class, drift::ChangeClass::Trivial))
+        .filter(|c| {
+            c.changes.iter().any(|info| match info.class {
+                drift::ChangeClass::BackwardIncompatible
+                | drift::ChangeClass::ForwardIncompatible
+                | drift::ChangeClass::Incompatible
+                | drift::ChangeClass::Unhandled => true,
+                drift::ChangeClass::Trivial => false,
+            })
+        })
         .collect();
     assert!(
         !non_trivial.is_empty(),


### PR DESCRIPTION
Split up the porting effort from the functional changes in upcoming PRs.
