### PR TITLE
consistently name test modules 'tests'

### DIFF
--- a/crates/dropshot-api-manager/src/cmd/dispatch.rs
+++ b/crates/dropshot-api-manager/src/cmd/dispatch.rs
@@ -318,7 +318,7 @@ pub const NEEDS_UPDATE_EXIT_CODE: u8 = 4;
 pub const FAILURE_EXIT_CODE: u8 = 100;
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::{
         environment::{

--- a/crates/dropshot-api-manager/src/compatibility/detect.rs
+++ b/crates/dropshot-api-manager/src/compatibility/detect.rs
@@ -420,7 +420,7 @@ pub fn change_class_str(class: &ChangeClass) -> &'static str {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/crates/dropshot-api-manager/src/iter_only.rs
+++ b/crates/dropshot-api-manager/src/iter_only.rs
@@ -37,7 +37,7 @@ pub fn iter_only<T: Debug>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use assert_matches::assert_matches;
 

--- a/crates/dropshot-api-manager/src/spec_files_generic.rs
+++ b/crates/dropshot-api-manager/src/spec_files_generic.rs
@@ -1018,7 +1018,7 @@ pub(crate) fn hash_contents(contents: &[u8]) -> String {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::ManagedApiConfig;
     use anyhow::Context;


### PR DESCRIPTION
We use `mod test` in some places and `mod tests` in others. Standardize on one of them (I prefer `tests`).
