### PR TITLE
[dropshot-api-manager] write output to a writer to make rendering testable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +666,18 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "expectorate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfe29c067b3dd398703f5cb05420a21c21079edfbcfa96c3ff2d9bde55cc8b3"
+dependencies = [
+ "atomicwrites",
+ "console",
+ "newline-converter",
+ "similar",
 ]
 
 [[package]]
@@ -1244,6 +1275,7 @@ dependencies = [
  "dropshot",
  "dropshot-api-manager",
  "dropshot-api-manager-types",
+ "expectorate",
  "git-stub",
  "git-stub-vcs",
  "http",
@@ -1415,6 +1447,15 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2608,6 +2649,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ dropshot = "0.17.0"
 dropshot-api-manager = { path = "crates/dropshot-api-manager", version = "0.7.1" }
 dropshot-api-manager-types = { path = "crates/dropshot-api-manager-types", version = "0.7.1" }
 e2e-example-apis = { path = "e2e-example/apis" }
+expectorate = "1.2.0"
 fs-err = "3.1.1"
 git-stub = "1.0.0"
 git-stub-vcs = "0.1.0"

--- a/crates/dropshot-api-manager/src/cmd/check.rs
+++ b/crates/dropshot-api-manager/src/cmd/check.rs
@@ -4,56 +4,74 @@ use crate::{
     apis::ManagedApis,
     environment::{BlessedSource, GeneratedSource, ResolvedEnv},
     output::{
-        CheckResult, OutputOpts, display_load_problems, display_resolution,
+        CheckResult, Styles, display_load_problems, display_resolution,
         headers::*,
     },
     resolved::{ProblemSummary, Resolved},
 };
+use std::io;
 
 pub(crate) fn check_impl(
+    writer: &mut dyn io::Write,
     apis: &ManagedApis,
     env: &ResolvedEnv,
     blessed_source: &BlessedSource,
     generated_source: &GeneratedSource,
-    output: &OutputOpts,
+    styles: &Styles,
 ) -> anyhow::Result<CheckResult> {
     let (result, _summaries) = check_impl_with_summaries(
+        writer,
         apis,
         env,
         blessed_source,
         generated_source,
-        output,
+        styles,
     )?;
     Ok(result)
 }
 
+/// Run the check pipeline, rendering all user-visible output to `writer`.
+///
+/// Production callers (the CLI dispatch path) pass `&mut
+/// std::io::stderr().lock()` along with [`OutputOpts::styles`]; tests pass a
+/// `Vec<u8>` and `Styles::default()` to capture the same output into a
+/// `String`.
 pub(crate) fn check_impl_with_summaries(
+    writer: &mut dyn io::Write,
     apis: &ManagedApis,
     env: &ResolvedEnv,
     blessed_source: &BlessedSource,
     generated_source: &GeneratedSource,
-    output: &OutputOpts,
+    styles: &Styles,
 ) -> anyhow::Result<(CheckResult, Vec<ProblemSummary>)> {
-    let styles = output.styles(supports_color::Stream::Stderr);
+    writeln!(writer, "{:>HEADER_WIDTH$}", SEPARATOR)?;
 
-    eprintln!("{:>HEADER_WIDTH$}", SEPARATOR);
+    let (generated, errors) = generated_source.load(
+        writer,
+        apis,
+        styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
+    display_load_problems(writer, &errors, styles)?;
 
-    let (generated, errors) =
-        generated_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
-    display_load_problems(&errors, &styles)?;
-
-    let (local_files, errors) =
-        env.local_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
-    display_load_problems(&errors, &styles)?;
+    let (local_files, errors) = env.local_source.load(
+        writer,
+        apis,
+        styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
+    display_load_problems(writer, &errors, styles)?;
 
     let (blessed, errors) =
-        blessed_source.load(&env.repo_root, apis, &styles, &env.vcs)?;
-    display_load_problems(&errors, &styles)?;
+        blessed_source.load(writer, &env.repo_root, apis, styles, &env.vcs)?;
+    display_load_problems(writer, &errors, styles)?;
 
     let resolved = Resolved::new(env, apis, &blessed, &generated, &local_files);
 
-    eprintln!("{:>HEADER_WIDTH$}", SEPARATOR);
-    let result = display_resolution(env, apis, &resolved, &styles)?;
+    writeln!(writer, "{:>HEADER_WIDTH$}", SEPARATOR)?;
+    let result = display_resolution(writer, env, apis, &resolved, styles)?;
 
     // Extract owned summaries before dropping the borrowed resolved state.
     let summaries = resolved.problem_summaries();

--- a/crates/dropshot-api-manager/src/cmd/debug.rs
+++ b/crates/dropshot-api-manager/src/cmd/debug.rs
@@ -20,21 +20,37 @@ pub(crate) fn debug_impl(
     output: &OutputOpts,
 ) -> anyhow::Result<()> {
     let styles = output.styles(supports_color::Stream::Stderr);
+    let mut stderr = std::io::stderr().lock();
 
     // Print information about local files.
 
-    let (local_files, errors) =
-        env.local_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
+    let (local_files, errors) = env.local_source.load(
+        &mut stderr,
+        apis,
+        &styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
     dump_structure(&local_files, &errors);
 
     // Print information about what we found in VCS history.
-    let (blessed, errors) =
-        blessed_source.load(&env.repo_root, apis, &styles, &env.vcs)?;
+    let (blessed, errors) = blessed_source.load(
+        &mut stderr,
+        &env.repo_root,
+        apis,
+        &styles,
+        &env.vcs,
+    )?;
     dump_structure(&blessed, &errors);
 
     // Print information about generated files.
-    let (generated, errors) =
-        generated_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
+    let (generated, errors) = generated_source.load(
+        &mut stderr,
+        apis,
+        &styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
     dump_structure(&generated, &errors);
 
     // Print result of resolving the differences.

--- a/crates/dropshot-api-manager/src/cmd/dispatch.rs
+++ b/crates/dropshot-api-manager/src/cmd/dispatch.rs
@@ -13,7 +13,7 @@ use crate::{
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::{Args, Parser, Subcommand};
-use std::process::ExitCode;
+use std::{io::Write as _, process::ExitCode};
 
 /// Manage OpenAPI documents for this repository.
 ///
@@ -41,7 +41,13 @@ impl App {
         match result {
             Ok(exit_code) => exit_code,
             Err(error) => {
-                eprintln!("failure: {:#}", error);
+                // Best-effort: if even the error report fails to write,
+                // we still want to exit with FAILURE.
+                let _ = writeln!(
+                    &mut std::io::stderr().lock(),
+                    "failure: {:#}",
+                    error,
+                );
                 ExitCode::FAILURE
             }
         }
@@ -300,8 +306,16 @@ impl CheckArgs {
         let env = env.resolve(self.local.dir)?;
         let blessed_source = self.blessed.to_blessed_source(&env)?;
         let generated_source = GeneratedSource::from(self.generated);
-        Ok(check_impl(apis, &env, &blessed_source, &generated_source, output)?
-            .to_exit_code())
+        let styles = output.styles(supports_color::Stream::Stderr);
+        Ok(check_impl(
+            &mut std::io::stderr().lock(),
+            apis,
+            &env,
+            &blessed_source,
+            &generated_source,
+            &styles,
+        )?
+        .to_exit_code())
     }
 }
 

--- a/crates/dropshot-api-manager/src/cmd/generate.rs
+++ b/crates/dropshot-api-manager/src/cmd/generate.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use anyhow::{Result, anyhow, bail};
 use owo_colors::OwoColorize;
-use std::process::ExitCode;
+use std::{io, process::ExitCode};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum GenerateResult {
@@ -39,32 +39,61 @@ pub(crate) fn generate_impl(
     output: &OutputOpts,
 ) -> Result<GenerateResult> {
     let styles = output.styles(supports_color::Stream::Stderr);
+    let mut stderr = std::io::stderr().lock();
+    generate_impl_inner(
+        &mut stderr,
+        apis,
+        env,
+        blessed_source,
+        generated_source,
+        &styles,
+    )
+}
 
-    let (generated, errors) =
-        generated_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
-    display_load_problems(&errors, &styles)?;
+fn generate_impl_inner(
+    writer: &mut dyn io::Write,
+    apis: &ManagedApis,
+    env: &ResolvedEnv,
+    blessed_source: &BlessedSource,
+    generated_source: &GeneratedSource,
+    styles: &Styles,
+) -> Result<GenerateResult> {
+    let (generated, errors) = generated_source.load(
+        writer,
+        apis,
+        styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
+    display_load_problems(writer, &errors, styles)?;
 
-    let (local_files, errors) =
-        env.local_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
-    display_load_problems(&errors, &styles)?;
+    let (local_files, errors) = env.local_source.load(
+        writer,
+        apis,
+        styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
+    display_load_problems(writer, &errors, styles)?;
 
     let (blessed, errors) =
-        blessed_source.load(&env.repo_root, apis, &styles, &env.vcs)?;
-    display_load_problems(&errors, &styles)?;
+        blessed_source.load(writer, &env.repo_root, apis, styles, &env.vcs)?;
+    display_load_problems(writer, &errors, styles)?;
 
     let resolved = Resolved::new(env, apis, &blessed, &generated, &local_files);
-    eprintln!("{:>HEADER_WIDTH$}", SEPARATOR);
+    writeln!(writer, "{:>HEADER_WIDTH$}", SEPARATOR)?;
 
     let total = resolved.nexpected_documents();
-    eprintln!(
+    writeln!(
+        writer,
         "{:>HEADER_WIDTH$} {} OpenAPI {}...",
         "Updating".style(styles.success_header),
         total.style(styles.bold),
         plural::documents(total),
-    );
+    )?;
 
     if resolved.has_unfixable_problems() {
-        return match display_resolution(env, apis, &resolved, &styles)? {
+        return match display_resolution(writer, env, apis, &resolved, styles)? {
             CheckResult::Failures => Ok(GenerateResult::Failures),
             unexpected => {
                 Err(anyhow!("unexpectedly got {unexpected:?} from summarize()"))
@@ -91,61 +120,68 @@ pub(crate) fn generate_impl(
 
             let problems: Vec<_> = resolution.problems().collect();
             if problems.is_empty() {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} {}",
                     UNCHANGED.style(styles.unchanged_header),
-                    display_api_spec_version(api, version, &styles, resolution),
-                );
+                    display_api_spec_version(api, version, styles, resolution),
+                )?;
                 num_unchanged += 1;
             } else {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} {}",
                     STALE.style(styles.warning_header),
-                    display_api_spec_version(api, version, &styles, resolution),
-                );
+                    display_api_spec_version(api, version, styles, resolution),
+                )?;
 
                 fix_problems(
+                    writer,
                     env,
                     problems,
-                    &styles,
+                    styles,
                     &mut num_updated,
                     &mut num_errors,
-                );
+                )?;
             }
         }
 
         if let Some(symlink_problem) = resolved.symlink_problem(ident) {
-            eprintln!(
+            writeln!(
+                writer,
                 "{:>HEADER_WIDTH$} {} \"latest\" symlink",
                 STALE.style(styles.warning_header),
                 ident.style(styles.filename),
-            );
+            )?;
 
             fix_problems(
+                writer,
                 env,
                 std::iter::once(symlink_problem),
-                &styles,
+                styles,
                 &mut num_updated,
                 &mut num_errors,
-            );
+            )?;
         } else if api.is_versioned() {
-            eprintln!(
+            writeln!(
+                writer,
                 "{:>HEADER_WIDTH$} {} \"latest\" symlink",
                 UNCHANGED.style(styles.unchanged_header),
                 ident.style(styles.filename),
-            );
+            )?;
         }
     }
 
     // Fix problems not associated with any supported version, if any.
     let general_problems: Vec<_> = resolved.general_problems().collect();
     fix_problems(
+        writer,
         env,
         general_problems,
-        &styles,
+        styles,
         &mut num_updated,
         &mut num_errors,
-    );
+    )?;
 
     // Done with the first resolution. Release borrows so the source
     // collections can be dropped in parallel later.
@@ -153,31 +189,38 @@ pub(crate) fn generate_impl(
 
     if num_errors > 0 {
         print_final_status(
-            &styles,
+            writer,
+            styles,
             total,
             num_updated,
             num_unchanged,
             num_errors,
-        );
+        )?;
         return Ok(GenerateResult::Failures);
     }
 
     // Finally, check again for any problems. Since we expect this should have
     // fixed everything, be quiet unless we find something amiss.
     let mut nproblems = 0;
-    let (local_files_recheck, errors) =
-        env.local_source.load(apis, &styles, &env.repo_root, &env.vcs)?;
-    eprintln!(
+    let (local_files_recheck, errors) = env.local_source.load(
+        writer,
+        apis,
+        styles,
+        &env.repo_root,
+        &env.vcs,
+    )?;
+    writeln!(
+        writer,
         "{:>HEADER_WIDTH$} all local files",
         "Rechecking".style(styles.success_header),
-    );
-    display_load_problems(&errors, &styles)?;
+    )?;
+    display_load_problems(writer, &errors, styles)?;
     let resolved =
         Resolved::new(env, apis, &blessed, &generated, &local_files_recheck);
     let general_problems: Vec<_> = resolved.general_problems().collect();
     nproblems += general_problems.len();
     if !general_problems.is_empty() {
-        display_resolution_problems(env, general_problems, &styles);
+        display_resolution_problems(writer, env, general_problems, styles)?;
     }
     for api in apis.iter_apis() {
         let ident = api.ident();
@@ -188,26 +231,29 @@ pub(crate) fn generate_impl(
             let problems: Vec<_> = resolution.problems().collect();
             nproblems += problems.len();
             if !problems.is_empty() {
-                eprintln!(
+                writeln!(
+                    writer,
                     "found unexpected problem with API {} version {} \
                      (this is a bug)",
                     ident, version
-                );
-                display_resolution_problems(env, problems, &styles);
+                )?;
+                display_resolution_problems(writer, env, problems, styles)?;
             }
         }
 
         if let Some(symlink_problem) = resolved.symlink_problem(ident) {
             nproblems += 1;
-            eprintln!(
+            writeln!(
+                writer,
                 "found unexpected problem with API {} symlink (this is a bug)",
                 ident
-            );
+            )?;
             display_resolution_problems(
+                writer,
                 env,
                 std::iter::once(symlink_problem),
-                &styles,
-            );
+                styles,
+            )?;
         }
     }
 
@@ -229,30 +275,33 @@ pub(crate) fn generate_impl(
         );
     } else {
         print_final_status(
-            &styles,
+            writer,
+            styles,
             total,
             num_updated,
             num_unchanged,
             num_errors,
-        );
+        )?;
         Ok(GenerateResult::Success)
     }
 }
 
 fn print_final_status(
+    writer: &mut dyn io::Write,
     styles: &Styles,
     ndocuments: usize,
     num_updated: usize,
     num_unchanged: usize,
     num_errors: usize,
-) {
-    eprintln!("{:>HEADER_WIDTH$}", SEPARATOR);
+) -> io::Result<()> {
+    writeln!(writer, "{:>HEADER_WIDTH$}", SEPARATOR)?;
     let status_header = if num_errors == 0 {
         headers::SUCCESS.style(styles.success_header)
     } else {
         headers::FAILURE.style(styles.failure_header)
     };
-    eprintln!(
+    writeln!(
+        writer,
         "{:>HEADER_WIDTH$} {} {}: {} {} made, {} unchanged, {} failed",
         status_header,
         ndocuments.style(styles.bold),
@@ -261,16 +310,19 @@ fn print_final_status(
         plural::changes(num_updated),
         num_unchanged.style(styles.bold),
         num_errors.style(styles.bold),
-    );
+    )?;
+    Ok(())
 }
 
 fn fix_problems<'a, T>(
+    writer: &mut dyn io::Write,
     env: &ResolvedEnv,
     problems: T,
     styles: &Styles,
     num_updated: &mut usize,
     num_errors: &mut usize,
-) where
+) -> io::Result<()>
+where
     T: IntoIterator<Item = &'a Problem<'a>>,
 {
     for p in problems {
@@ -281,22 +333,25 @@ fn fix_problems<'a, T>(
             Ok(steps) => {
                 *num_updated += 1;
                 for s in steps {
-                    eprintln!(
+                    writeln!(
+                        writer,
                         "{:>HEADER_WIDTH$} {}",
                         "Fixed".style(styles.success_header),
                         s,
-                    );
+                    )?;
                 }
             }
             Err(error) => {
                 *num_errors += 1;
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} fix {:?}: {:#}",
                     "FIX FAILED".style(styles.failure_header),
                     fix.to_string(),
                     error
-                );
+                )?;
             }
         }
     }
+    Ok(())
 }

--- a/crates/dropshot-api-manager/src/environment.rs
+++ b/crates/dropshot-api-manager/src/environment.rs
@@ -18,6 +18,7 @@ use crate::{
 use anyhow::Context;
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use owo_colors::OwoColorize;
+use std::io;
 
 /// Default Git branch for the blessed source.
 const DEFAULT_GIT_BRANCH: &str = "origin/main";
@@ -289,6 +290,7 @@ impl BlessedSource {
     /// Load the blessed OpenAPI documents.
     pub fn load(
         &self,
+        writer: &mut dyn io::Write,
         repo_root: &Utf8Path,
         apis: &ManagedApis,
         styles: &Styles,
@@ -297,11 +299,12 @@ impl BlessedSource {
         let mut errors = ErrorAccumulator::new();
         match self {
             BlessedSource::Directory { local_directory } => {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} blessed OpenAPI documents from {:?}",
                     "Loading".style(styles.success_header),
                     local_directory,
-                );
+                )?;
                 let api_files: ApiSpecFilesBuilder<'_, BlessedApiSpecFile> =
                     walk_local_directory(
                         local_directory,
@@ -313,13 +316,14 @@ impl BlessedSource {
                 Ok((BlessedFiles::from(api_files), errors))
             }
             BlessedSource::VcsRevisionMergeBase { revision, directory } => {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} blessed OpenAPI documents from VCS \
                      revision {:?} path {:?}",
                     "Loading".style(styles.success_header),
                     revision,
                     directory
-                );
+                )?;
                 Ok((
                     BlessedFiles::load_from_vcs_parent_branch(
                         repo_root,
@@ -352,6 +356,7 @@ impl GeneratedSource {
     /// Load the generated OpenAPI documents (i.e., generating them as needed).
     pub fn load(
         &self,
+        writer: &mut dyn io::Write,
         apis: &ManagedApis,
         styles: &Styles,
         repo_root: &Utf8Path,
@@ -360,20 +365,22 @@ impl GeneratedSource {
         let mut errors = ErrorAccumulator::new();
         match self {
             GeneratedSource::Generated => {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} OpenAPI documents from API \
                      definitions ... ",
                     GENERATING.style(styles.success_header)
-                );
+                )?;
                 Ok((GeneratedFiles::generate(apis, &mut errors)?, errors))
             }
             GeneratedSource::Directory { local_directory } => {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} \"generated\" OpenAPI documents from \
                      {:?} ... ",
                     "Loading".style(styles.success_header),
                     local_directory,
-                );
+                )?;
                 let api_files = walk_local_directory(
                     local_directory,
                     apis,
@@ -406,6 +413,7 @@ impl LocalSource {
     /// The `repo_root` parameter is needed to resolve `.gitstub` files.
     pub fn load(
         &self,
+        writer: &mut dyn io::Write,
         apis: &ManagedApis,
         styles: &Styles,
         repo_root: &Utf8Path,
@@ -416,7 +424,7 @@ impl LocalSource {
         // Shallow clones and Git stub storage are incompatible.
         let any_uses_git_stub =
             apis.iter_apis().any(|a| apis.uses_git_stub_storage(a));
-        if any_uses_git_stub && vcs.is_shallow_clone(repo_root) {
+        if any_uses_git_stub && vcs.is_shallow_clone(writer, repo_root) {
             errors.error(anyhow::anyhow!(
                 "this repository is a shallow clone, but Git stub storage is \
                  enabled for some APIs. Git stubs cannot be resolved in a \
@@ -430,12 +438,13 @@ impl LocalSource {
 
         match self {
             LocalSource::Directory { abs_dir, .. } => {
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} local OpenAPI documents from \
                      {:?} ... ",
                     "Loading".style(styles.success_header),
                     abs_dir,
-                );
+                )?;
                 Ok((
                     LocalFiles::load_from_directory(
                         abs_dir,

--- a/crates/dropshot-api-manager/src/output.rs
+++ b/crates/dropshot-api-manager/src/output.rs
@@ -93,10 +93,13 @@ where
     'diff: 'old + 'new + 'bufs,
     T: DiffableStr + ?Sized,
 {
-    // The "a/" (/ courtesy full_path) and "b/" make it feel more like git diff.
-    let a = Utf8Path::new("a").join(path1);
+    // The "a/" and "b/" prefixes make this feel more like a git diff. We
+    // assemble the header by hand (and normalize any backslashes in the
+    // path) so the output is forward-slashed regardless of host OS, which
+    // is the convention every diff/patch tool expects.
+    let a = format_diff_path("a", path1);
     writeln!(out, "{}", format!("--- {a}").style(styles.diff_before))?;
-    let b = Utf8Path::new("b").join(path2);
+    let b = format_diff_path("b", path2);
     writeln!(out, "{}", format!("+++ {b}").style(styles.diff_after))?;
 
     let mut udiff = diff.unified_diff();
@@ -130,6 +133,17 @@ where
     }
 
     Ok(())
+}
+
+/// Format a `prefix/path` header for unified diff output, normalizing
+/// path separators to `/` so the rendered output is identical on Windows
+/// and Unix (and matches the diff/patch convention).
+fn format_diff_path(prefix: &str, path: &Utf8Path) -> String {
+    if std::path::MAIN_SEPARATOR == '/' {
+        format!("{prefix}/{path}")
+    } else {
+        format!("{prefix}/{}", path.as_str().replace('\\', "/"))
+    }
 }
 
 pub(crate) fn display_api_spec(api: &ManagedApi, styles: &Styles) -> String {

--- a/crates/dropshot-api-manager/src/output.rs
+++ b/crates/dropshot-api-manager/src/output.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use crate::{
     FAILURE_EXIT_CODE, NEEDS_UPDATE_EXIT_CODE,
@@ -223,25 +223,28 @@ impl fmt::Display for MissingNewlineHint {
 }
 
 pub fn display_load_problems(
+    writer: &mut dyn io::Write,
     error_accumulator: &ErrorAccumulator,
     styles: &Styles,
 ) -> anyhow::Result<()> {
     for w in error_accumulator.iter_warnings() {
-        eprintln!(
+        writeln!(
+            writer,
             "{:>HEADER_WIDTH$} {:#}",
             WARNING.style(styles.warning_header),
             w
-        );
+        )?;
     }
 
     let mut nerrors = 0;
     for e in error_accumulator.iter_errors() {
         nerrors += 1;
-        eprintln!(
+        writeln!(
+            writer,
             "{:>HEADER_WIDTH$} {:#}",
             FAILURE.style(styles.failure_header),
             e
-        );
+        )?;
     }
 
     if nerrors > 0 {
@@ -258,6 +261,7 @@ pub fn display_load_problems(
 /// Summarize the results of checking all supported API versions, plus other
 /// problems found during resolution
 pub fn display_resolution(
+    writer: &mut dyn io::Write,
     env: &ResolvedEnv,
     apis: &ManagedApis,
     resolved: &Resolved,
@@ -265,12 +269,13 @@ pub fn display_resolution(
 ) -> anyhow::Result<CheckResult> {
     let total = resolved.nexpected_documents();
 
-    eprintln!(
+    writeln!(
+        writer,
         "{:>HEADER_WIDTH$} {} OpenAPI {}...",
         CHECKING.style(styles.success_header),
         total.style(styles.bold),
         plural::documents(total),
-    );
+    )?;
 
     let mut num_fresh = 0;
     let mut num_stale = 0;
@@ -293,7 +298,7 @@ pub fn display_resolution(
             } else {
                 num_fresh += 1;
             }
-            summarize_one(env, api, version, resolution, styles);
+            summarize_one(writer, env, api, version, resolution, styles)?;
         }
 
         if !api.is_versioned() {
@@ -303,52 +308,58 @@ pub fn display_resolution(
         if let Some(symlink_problem) = resolved.symlink_problem(ident) {
             if symlink_problem.is_fixable() {
                 num_general_problems += 1;
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} {} \"latest\" symlink",
                     STALE.style(styles.warning_header),
                     ident.style(styles.filename),
-                );
+                )?;
                 display_resolution_problems(
+                    writer,
                     env,
                     std::iter::once(symlink_problem),
                     styles,
-                );
+                )?;
             } else {
                 num_failed += 1;
-                eprintln!(
+                writeln!(
+                    writer,
                     "{:>HEADER_WIDTH$} {} \"latest\" symlink",
                     FAILURE.style(styles.failure_header),
                     ident.style(styles.filename),
-                );
+                )?;
                 display_resolution_problems(
+                    writer,
                     env,
                     std::iter::once(symlink_problem),
                     styles,
-                );
+                )?;
             }
         } else {
             num_fresh += 1;
-            eprintln!(
+            writeln!(
+                writer,
                 "{:>HEADER_WIDTH$} {} \"latest\" symlink",
                 FRESH.style(styles.success_header),
                 ident.style(styles.filename),
-            );
+            )?;
         }
     }
 
     // Print problems not associated with any supported version, if any.
     let general_problems: Vec<_> = resolved.general_problems().collect();
     num_general_problems += if !general_problems.is_empty() {
-        eprintln!(
+        writeln!(
+            writer,
             "\n{:>HEADER_WIDTH$} problems not associated with a specific \
              supported API version:",
             "Other".style(styles.warning_header),
-        );
+        )?;
 
         let (fixable, unfixable): (Vec<&Problem>, Vec<&Problem>) =
             general_problems.iter().partition(|p| p.is_fixable());
         num_failed += unfixable.len();
-        display_resolution_problems(env, general_problems, styles);
+        display_resolution_problems(writer, env, general_problems, styles)?;
         fixable.len()
     } else {
         0
@@ -359,7 +370,8 @@ pub fn display_resolution(
         let initial_indent =
             format!("{:>HEADER_WIDTH$} ", "Note".style(styles.warning_header));
         let more_indent = " ".repeat(HEADER_WIDTH + " ".len());
-        eprintln!(
+        writeln!(
+            writer,
             "\n{}\n",
             textwrap::fill(
                 &n.to_string(),
@@ -367,7 +379,7 @@ pub fn display_resolution(
                     .initial_indent(&initial_indent)
                     .subsequent_indent(&more_indent)
             )
-        );
+        )?;
     }
 
     // Print a summary line.
@@ -379,8 +391,9 @@ pub fn display_resolution(
         SUCCESS.style(styles.success_header)
     };
 
-    eprintln!("{:>HEADER_WIDTH$}", SEPARATOR);
-    eprintln!(
+    writeln!(writer, "{:>HEADER_WIDTH$}", SEPARATOR)?;
+    writeln!(
+        writer,
         "{:>HEADER_WIDTH$} {} {} checked: {} fresh, {} stale, {} failed, \
          {} other {}",
         status_header,
@@ -391,20 +404,22 @@ pub fn display_resolution(
         num_failed.style(styles.bold),
         num_general_problems.style(styles.bold),
         plural::problems(num_general_problems),
-    );
+    )?;
     if num_failed > 0 {
-        eprintln!(
+        writeln!(
+            writer,
             "{:>HEADER_WIDTH$} (fix failures, then run {} to update)",
             "",
             format!("{} generate", env.command).style(styles.bold)
-        );
+        )?;
         Ok(CheckResult::Failures)
     } else if num_stale > 0 || num_general_problems > 0 {
-        eprintln!(
+        writeln!(
+            writer,
             "{:>HEADER_WIDTH$} (run {} to update)",
             "",
             format!("{} generate", env.command).style(styles.bold)
-        );
+        )?;
         Ok(CheckResult::NeedsUpdate)
     } else {
         Ok(CheckResult::Success)
@@ -437,23 +452,26 @@ impl CheckResult {
 
 /// Summarize the "check" status of one supported API version
 fn summarize_one(
+    writer: &mut dyn io::Write,
     env: &ResolvedEnv,
     api: &ManagedApi,
     version: &semver::Version,
     resolution: &Resolution<'_>,
     styles: &Styles,
-) {
+) -> io::Result<()> {
     let problems: Vec<_> = resolution.problems().collect();
     if problems.is_empty() {
         // Success case: file is up-to-date.
-        eprintln!(
+        writeln!(
+            writer,
             "{:>HEADER_WIDTH$} {}",
             FRESH.style(styles.success_header),
             display_api_spec_version(api, version, styles, resolution),
-        );
+        )?;
     } else {
         // There were one or more problems, some of which may be unfixable.
-        eprintln!(
+        writeln!(
+            writer,
             "{:>HEADER_WIDTH$} {}",
             if resolution.has_errors() {
                 FAILURE.style(styles.failure_header)
@@ -462,18 +480,21 @@ fn summarize_one(
                 STALE.style(styles.warning_header)
             },
             display_api_spec_version(api, version, styles, resolution),
-        );
+        )?;
 
-        display_resolution_problems(env, problems, styles);
+        display_resolution_problems(writer, env, problems, styles)?;
     }
+    Ok(())
 }
 
-/// Print a formatted list of Problems
+/// Print a formatted list of Problems to `writer`.
 pub fn display_resolution_problems<'a, T>(
+    writer: &mut dyn io::Write,
     env: &ResolvedEnv,
     problems: T,
     styles: &Styles,
-) where
+) -> io::Result<()>
+where
     T: IntoIterator<Item = &'a Problem<'a>>,
 {
     for p in problems.into_iter() {
@@ -487,7 +508,8 @@ pub fn display_resolution_problems<'a, T>(
             }
         );
         let more_indent = " ".repeat(subheader_width + 2);
-        eprintln!(
+        writeln!(
+            writer,
             "{}",
             textwrap::fill(
                 &InlineErrorChain::new(&p).to_string(),
@@ -495,7 +517,7 @@ pub fn display_resolution_problems<'a, T>(
                     .initial_indent(&first_indent)
                     .subsequent_indent(&more_indent)
             )
-        );
+        )?;
 
         // For BlessedVersionBroken, print each item separately, along with a
         // diff between blessed and generated versions.
@@ -505,7 +527,8 @@ pub fn display_resolution_problems<'a, T>(
                 // "- ".
                 let nested_first_indent = format!("{}- ", more_indent);
                 let nested_more_indent = format!("{}  ", more_indent);
-                eprintln!(
+                writeln!(
+                    writer,
                     "{}",
                     textwrap::fill(
                         &issue.to_string(),
@@ -513,7 +536,7 @@ pub fn display_resolution_problems<'a, T>(
                             .initial_indent(&nested_first_indent)
                             .subsequent_indent(&nested_more_indent)
                     )
-                );
+                )?;
 
                 // Now print a textual diff between the blessed and generated
                 // versions.
@@ -521,9 +544,7 @@ pub fn display_resolution_problems<'a, T>(
                 let generated_json = issue.generated_json();
 
                 let diff = TextDiff::from_lines(&blessed_json, &generated_json);
-                // We don't care about I/O errors here (just as we don't when
-                // using eprintln! above).
-                let _ = write_diff(
+                write_diff(
                     &diff,
                     "blessed".as_ref(),
                     "generated".as_ref(),
@@ -535,9 +556,9 @@ pub fn display_resolution_problems<'a, T>(
                     // Add an indent to align diff with the status message.
                     &mut indent_write::io::IndentWriter::new(
                         &nested_more_indent,
-                        std::io::stderr(),
+                        &mut *writer,
                     ),
-                );
+                )?;
             }
         }
 
@@ -555,7 +576,7 @@ pub fn display_resolution_problems<'a, T>(
             let path2 =
                 env.openapi_abs_dir().join(generated.spec_file_name().path());
             let indent = " ".repeat(HEADER_WIDTH + 1);
-            let _ = write_diff(
+            write_diff(
                 &diff,
                 &path1,
                 &path2,
@@ -563,11 +584,8 @@ pub fn display_resolution_problems<'a, T>(
                 // context_radius: show enough context to understand the changes.
                 3,
                 /* missing_newline_hint */ true,
-                &mut indent_write::io::IndentWriter::new(
-                    &indent,
-                    std::io::stderr(),
-                ),
-            );
+                &mut indent_write::io::IndentWriter::new(&indent, &mut *writer),
+            )?;
         }
 
         let Some(fix) = p.fix() else {
@@ -581,7 +599,8 @@ pub fn display_resolution_problems<'a, T>(
         let fix_str = fix.to_string();
         let steps = fix_str.trim_end().split("\n");
         for s in steps {
-            eprintln!(
+            writeln!(
+                writer,
                 "{}",
                 textwrap::fill(
                     &format!("will {}", s),
@@ -589,7 +608,7 @@ pub fn display_resolution_problems<'a, T>(
                         .initial_indent(&first_indent)
                         .subsequent_indent(&more_indent)
                 )
-            );
+            )?;
         }
 
         // When possible, print a useful diff of changes.
@@ -634,9 +653,7 @@ pub fn display_resolution_problems<'a, T>(
 
         if let Some((diff, path1, path2)) = do_diff {
             let indent = " ".repeat(HEADER_WIDTH + 1);
-            // We don't care about I/O errors here (just as we don't when using
-            // eprintln! above).
-            let _ = write_diff(
+            write_diff(
                 &diff,
                 &path1,
                 &path2,
@@ -646,14 +663,12 @@ pub fn display_resolution_problems<'a, T>(
                 3,
                 /* missing_newline_hint */ true,
                 // Add an indent to align diff with the status message.
-                &mut indent_write::io::IndentWriter::new(
-                    &indent,
-                    std::io::stderr(),
-                ),
-            );
-            eprintln!();
+                &mut indent_write::io::IndentWriter::new(&indent, &mut *writer),
+            )?;
+            writeln!(writer)?;
         }
     }
+    Ok(())
 }
 
 /// Adapter for [`Error`]s that provides a [`std::fmt::Display`] implementation

--- a/crates/dropshot-api-manager/src/test_util.rs
+++ b/crates/dropshot-api-manager/src/test_util.rs
@@ -12,9 +12,10 @@ use crate::{
         dispatch::{BlessedSourceArgs, GeneratedSourceArgs},
     },
     environment::{Environment, GeneratedSource},
-    output::OutputOpts,
+    output::{OutputOpts, Styles},
     resolved,
 };
+use anyhow::Context;
 use camino::Utf8PathBuf;
 
 /// Check that a set of APIs is up-to-date.
@@ -46,6 +47,9 @@ pub fn check_apis_with_generated_from_dir(
 
 /// Like [`check_apis_up_to_date`], but also returns the list of problem
 /// summaries for detailed assertions in tests.
+///
+/// The rendered output is written to stderr. To capture the rendered output
+/// into a `String` instead, use [`check_apis_with_render`].
 #[doc(hidden)]
 pub fn check_apis_with_summaries(
     env: &Environment,
@@ -54,12 +58,14 @@ pub fn check_apis_with_summaries(
     let env = resolve_env(env)?;
     let (blessed_source, generated_source, output) =
         default_sources(&env, None)?;
+    let styles = output.styles(supports_color::Stream::Stderr);
     check_impl_with_summaries(
+        &mut std::io::stderr().lock(),
         apis,
         &env,
         &blessed_source,
         &generated_source,
-        &output,
+        &styles,
     )
 }
 
@@ -74,13 +80,42 @@ pub fn check_apis_with_generated_from_dir_and_summaries(
     let env = resolve_env(env)?;
     let (blessed_source, generated_source, output) =
         default_sources(&env, Some(generated_from_dir))?;
+    let styles = output.styles(supports_color::Stream::Stderr);
     check_impl_with_summaries(
+        &mut std::io::stderr().lock(),
         apis,
         &env,
         &blessed_source,
         &generated_source,
-        &output,
+        &styles,
     )
+}
+
+/// Like [`check_apis_with_summaries`], but captures the rendered check output
+/// into a `String` rather than writing it to stderr. Styling is disabled.
+#[doc(hidden)]
+pub fn check_apis_with_render(
+    env: &Environment,
+    apis: &ManagedApis,
+) -> Result<(CheckResult, Vec<resolved::ProblemSummary>, String), anyhow::Error>
+{
+    let env = resolve_env(env)?;
+    let (blessed_source, generated_source, _output) =
+        default_sources(&env, None)?;
+    // Force defaults (no color) so the captured snapshot is terminal-agnostic.
+    let styles = Styles::default();
+    let mut buf: Vec<u8> = Vec::new();
+    let (result, summaries) = check_impl_with_summaries(
+        &mut buf,
+        apis,
+        &env,
+        &blessed_source,
+        &generated_source,
+        &styles,
+    )?;
+    let rendered = String::from_utf8(buf)
+        .context("rendered output should be valid UTF-8")?;
+    Ok((result, summaries, rendered))
 }
 
 fn resolve_env(

--- a/crates/dropshot-api-manager/src/vcs/imp.rs
+++ b/crates/dropshot-api-manager/src/vcs/imp.rs
@@ -192,11 +192,18 @@ impl RepoVcs {
     /// cost of potentially incorrect behavior if the repo truly is
     /// shallow; the downstream git-stub resolution will surface a
     /// clearer error in that case.
-    pub(crate) fn is_shallow_clone(&self, repo_root: &Utf8Path) -> bool {
+    pub(crate) fn is_shallow_clone(
+        &self,
+        writer: &mut dyn std::io::Write,
+        repo_root: &Utf8Path,
+    ) -> bool {
         match self.stub_vcs.is_shallow_clone(repo_root) {
             Ok(is_shallow) => is_shallow,
             Err(err) => {
-                eprintln!(
+                // Best-effort: if the warning itself fails to write, the
+                // underlying behavior (returning `false`) is unchanged.
+                let _ = writeln!(
+                    writer,
                     "warning: failed to check if repository is a \
                      shallow clone: {err:#}"
                 );

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -30,6 +30,7 @@ serde_json.workspace = true
 assert_matches.workspace = true
 atomicwrites.workspace = true
 drift.workspace = true
+expectorate.workspace = true
 
 [package.metadata.release]
 release = false

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -962,12 +962,14 @@ fn test_incompatible_blessed_api_change_render() -> Result<()> {
     assert_eq!(result, CheckResult::Failures);
 
     // The "Loading local OpenAPI documents from <abs_dir>" line embeds the
-    // tempdir path, which varies per run. Replace the entire path with a
-    // stable placeholder — replacing only the workspace prefix would leave
-    // a trailing `/documents` (or `\documents` on Windows) that's
-    // separator-sensitive.
-    let documents_dir = env.documents_dir().as_str();
-    let normalized = rendered.replace(documents_dir, "<documents dir>");
+    // tempdir path, which varies per run. The path is rendered with `{:?}`
+    // (Debug), which on Windows escapes backslashes — so we have to match
+    // the Debug-formatted form (which includes surrounding quotes), not
+    // the raw `as_str()` form, otherwise the replacement silently no-ops
+    // on Windows. The placeholder restores the quotes so the line still
+    // reads naturally.
+    let documents_dir_debug = format!("{:?}", env.documents_dir());
+    let normalized = rendered.replace(&documents_dir_debug, "\"<documents dir>\"");
 
     let snapshot_path = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/output/integration/blessed_version_broken.txt");

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -12,7 +12,7 @@ use dropshot_api_manager::{
     ManagedApi, ManagedApis,
     test_util::{
         CheckResult, ProblemKind, ProblemSummary, check_apis_up_to_date,
-        check_apis_with_summaries,
+        check_apis_with_render, check_apis_with_summaries,
     },
 };
 use integration_tests::*;
@@ -942,6 +942,36 @@ fn test_retiring_older_blessed_version() -> Result<()> {
         )],
     );
 
+    Ok(())
+}
+
+/// Snapshot the rendered `BlessedVersionBroken` output. The fixture is the
+/// same one that drives `test_incompatible_blessed_api_change`. The snapshot
+/// is intended to evolve alongside the rendering code, so that reviewers can
+/// see exactly how the user-visible output changes.
+#[test]
+fn test_incompatible_blessed_api_change_render() -> Result<()> {
+    let env = TestEnvironment::new_git()?;
+    let original_apis = versioned_health_apis()?;
+    env.generate_documents(&original_apis)?;
+    env.commit_documents()?;
+
+    let incompatible_apis = versioned_health_incompat_apis()?;
+    let (result, _summaries, rendered) =
+        check_apis_with_render(env.environment(), &incompatible_apis)?;
+    assert_eq!(result, CheckResult::Failures);
+
+    // The "Loading local OpenAPI documents from <abs_dir>" line embeds the
+    // tempdir path, which varies per run. Replace the entire path with a
+    // stable placeholder — replacing only the workspace prefix would leave
+    // a trailing `/documents` (or `\documents` on Windows) that's
+    // separator-sensitive.
+    let documents_dir = env.documents_dir().as_str();
+    let normalized = rendered.replace(documents_dir, "<documents dir>");
+
+    let snapshot_path = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/output/integration/blessed_version_broken.txt");
+    expectorate::assert_contents(snapshot_path, &normalized);
     Ok(())
 }
 

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -969,7 +969,8 @@ fn test_incompatible_blessed_api_change_render() -> Result<()> {
     // on Windows. The placeholder restores the quotes so the line still
     // reads naturally.
     let documents_dir_debug = format!("{:?}", env.documents_dir());
-    let normalized = rendered.replace(&documents_dir_debug, "\"<documents dir>\"");
+    let normalized =
+        rendered.replace(&documents_dir_debug, "\"<documents dir>\"");
 
     let snapshot_path = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/output/integration/blessed_version_broken.txt");

--- a/crates/integration-tests/tests/output/integration/blessed_version_broken.txt
+++ b/crates/integration-tests/tests/output/integration/blessed_version_broken.txt
@@ -1,0 +1,45 @@
+     -------
+  Generating OpenAPI documents from API definitions ... 
+     Loading local OpenAPI documents from "<documents dir>" ... 
+     Loading blessed OpenAPI documents from VCS revision "main" path "documents"
+     -------
+    Checking 3 OpenAPI documents...
+       Fresh versioned-health (versioned v1.0.0 (blessed)): Versioned Health API
+       Fresh versioned-health (versioned v2.0.0 (blessed)): Versioned Health API
+     Failure versioned-health (versioned v3.0.0 (blessed)): Versioned Health API
+           error: OpenAPI document generated from the current code is not
+                  compatible with the blessed document (from upstream)
+                  - at .paths."/system/info".get: forward-incompatible change:
+                    The operation get_system_info was added
+                    --- a/blessed
+                    +++ b/generated
+                    @@ -0,0 +1,25 @@
+                    +{
+                    +  "get": {
+                    +    "description": "This breaks backward compatibility by adding a new endpoint to v3.0.0.",
+                    +    "operationId": "get_system_info",
+                    +    "responses": {
+                    +      "200": {
+                    +        "content": {
+                    +          "application/json": {
+                    +            "schema": {
+                    +              "$ref": "#/components/schemas/SystemInfo"
+                    +            }
+                    +          }
+                    +        },
+                    +        "description": "successful operation"
+                    +      },
+                    +      "4XX": {
+                    +        "$ref": "#/components/responses/Error"
+                    +      },
+                    +      "5XX": {
+                    +        "$ref": "#/components/responses/Error"
+                    +      }
+                    +    },
+                    +    "summary": "Get system info (v3+): new endpoint added to existing version."
+                    +  }
+                    +}
+       Fresh versioned-health "latest" symlink
+     -------
+     Failure 3 documents checked: 3 fresh, 0 stale, 1 failed, 0 other problems
+             (fix failures, then run test-openapi-manager generate to update)


### PR DESCRIPTION
In upcoming work we're going to change some of this rendering. Make it testable by writing to a `&mut dyn io::Write`, and add an expectorate snapshot test.