### PR TITLE
[integration-tests] extend versioned_health_incompat with a param add

### DIFF
--- a/crates/integration-tests/src/fixtures.rs
+++ b/crates/integration-tests/src/fixtures.rs
@@ -1108,6 +1108,9 @@ pub mod versioned_health_incompat {
         ) -> Result<HttpResponseOk<HealthStatusV1>, HttpError>;
 
         /// Get detailed health status (v2+).
+        ///
+        /// Adds a required query parameter `verbose` relative to the
+        /// blessed shape. See `DetailedFilter` below.
         #[endpoint {
             method = GET,
             path = "/health/detailed",
@@ -1116,6 +1119,7 @@ pub mod versioned_health_incompat {
         }]
         async fn detailed_health_check(
             rqctx: RequestContext<Self::Context>,
+            query: Query<DetailedFilter>,
         ) -> Result<HttpResponseOk<DetailedHealthStatus>, HttpError>;
 
         /// Get service metrics (v3+).
@@ -1157,6 +1161,15 @@ pub mod versioned_health_incompat {
     pub use super::versioned_health::{
         DependencyStatus, DetailedHealthStatus, HealthStatusV1, ServiceMetrics,
     };
+
+    /// Required query parameter added to `detailed_health_check`. This is
+    /// drift's second asymmetric-path case (operation on the missing side,
+    /// parameter on the present side) — see comments on the test that
+    /// exercises this fixture.
+    #[derive(Debug, Deserialize, JsonSchema)]
+    pub struct DetailedFilter {
+        pub verbose: bool,
+    }
 }
 
 /// Versioned health API with 4 versions (adds v4 to the base API). Used to test

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -978,7 +978,6 @@ fn test_incompatible_blessed_api_change_render() -> Result<()> {
     Ok(())
 }
 
-
 #[test]
 fn test_incompatible_blessed_api_change() -> Result<()> {
     let env = TestEnvironment::new_git()?;

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -978,6 +978,7 @@ fn test_incompatible_blessed_api_change_render() -> Result<()> {
     Ok(())
 }
 
+
 #[test]
 fn test_incompatible_blessed_api_change() -> Result<()> {
     let env = TestEnvironment::new_git()?;
@@ -1016,8 +1017,10 @@ fn test_incompatible_blessed_api_change() -> Result<()> {
         .unwrap()
     );
 
-    // Now introduce incompatible changes. This adds a new endpoint, which
-    // (while forward-compatible) we treat as a breaking change.
+    // Now introduce incompatible changes. The incompat fixture adds a new
+    // endpoint to v3.0.0 and adds a new required query parameter to
+    // `detailed_health_check` (which is in v2.0.0+), so both v2.0.0 and
+    // v3.0.0 are reported as broken.
     let incompatible_apis = versioned_health_incompat_apis()?;
 
     // This check should return Failures.
@@ -1026,11 +1029,18 @@ fn test_incompatible_blessed_api_change() -> Result<()> {
     assert_eq!(result, CheckResult::Failures);
     assert_eq!(
         summaries,
-        [ProblemSummary::new(
-            "versioned-health",
-            "3.0.0",
-            ProblemKind::BlessedVersionBroken,
-        )],
+        [
+            ProblemSummary::new(
+                "versioned-health",
+                "2.0.0",
+                ProblemKind::BlessedVersionBroken,
+            ),
+            ProblemSummary::new(
+                "versioned-health",
+                "3.0.0",
+                ProblemKind::BlessedVersionBroken,
+            ),
+        ],
     );
 
     Ok(())

--- a/crates/integration-tests/tests/output/integration/blessed_version_broken.txt
+++ b/crates/integration-tests/tests/output/integration/blessed_version_broken.txt
@@ -5,7 +5,36 @@
      -------
     Checking 3 OpenAPI documents...
        Fresh versioned-health (versioned v1.0.0 (blessed)): Versioned Health API
-       Fresh versioned-health (versioned v2.0.0 (blessed)): Versioned Health API
+     Failure versioned-health (versioned v2.0.0 (blessed)): Versioned Health API
+           error: OpenAPI document generated from the current code is not
+                  compatible with the blessed document (from upstream)
+                  - at .paths."/health/detailed".get: backward-incompatible
+                    change: A new, required parameter 'verbose' was added
+                    --- a/blessed
+                    +++ b/generated
+                    @@ -1,11 +1,22 @@
+                     {
+                       "get": {
+                    +    "description": "Adds a required query parameter `verbose` relative to the blessed shape — see `DetailedFilter` below.",
+                         "operationId": "detailed_health_check",
+                    +    "parameters": [
+                    +      {
+                    +        "in": "query",
+                    +        "name": "verbose",
+                    +        "required": true,
+                    +        "schema": {
+                    +          "type": "boolean"
+                    +        }
+                    +      }
+                    +    ],
+                         "responses": {
+                           "200": {
+                             "content": {
+                               "application/json": {
+                                 "schema": {
+                                   "$ref": "#/components/schemas/DetailedHealthStatus"
+                                 }
+                               }
      Failure versioned-health (versioned v3.0.0 (blessed)): Versioned Health API
            error: OpenAPI document generated from the current code is not
                   compatible with the blessed document (from upstream)
@@ -39,7 +68,34 @@
                     +    "summary": "Get system info (v3+): new endpoint added to existing version."
                     +  }
                     +}
+                  - at .paths."/health/detailed".get: backward-incompatible
+                    change: A new, required parameter 'verbose' was added
+                    --- a/blessed
+                    +++ b/generated
+                    @@ -1,11 +1,22 @@
+                     {
+                       "get": {
+                    +    "description": "Adds a required query parameter `verbose` relative to the blessed shape — see `DetailedFilter` below.",
+                         "operationId": "detailed_health_check",
+                    +    "parameters": [
+                    +      {
+                    +        "in": "query",
+                    +        "name": "verbose",
+                    +        "required": true,
+                    +        "schema": {
+                    +          "type": "boolean"
+                    +        }
+                    +      }
+                    +    ],
+                         "responses": {
+                           "200": {
+                             "content": {
+                               "application/json": {
+                                 "schema": {
+                                   "$ref": "#/components/schemas/DetailedHealthStatus"
+                                 }
+                               }
        Fresh versioned-health "latest" symlink
      -------
-     Failure 3 documents checked: 3 fresh, 0 stale, 1 failed, 0 other problems
+     Failure 3 documents checked: 2 fresh, 0 stale, 2 failed, 0 other problems
              (fix failures, then run test-openapi-manager generate to update)

--- a/crates/integration-tests/tests/output/integration/blessed_version_broken.txt
+++ b/crates/integration-tests/tests/output/integration/blessed_version_broken.txt
@@ -15,7 +15,7 @@
                     @@ -1,11 +1,22 @@
                      {
                        "get": {
-                    +    "description": "Adds a required query parameter `verbose` relative to the blessed shape — see `DetailedFilter` below.",
+                    +    "description": "Adds a required query parameter `verbose` relative to the blessed shape. See `DetailedFilter` below.",
                          "operationId": "detailed_health_check",
                     +    "parameters": [
                     +      {
@@ -75,7 +75,7 @@
                     @@ -1,11 +1,22 @@
                      {
                        "get": {
-                    +    "description": "Adds a required query parameter `verbose` relative to the blessed shape — see `DetailedFilter` below.",
+                    +    "description": "Adds a required query parameter `verbose` relative to the blessed shape. See `DetailedFilter` below.",
                          "operationId": "detailed_health_check",
                     +    "parameters": [
                     +      {


### PR DESCRIPTION
This is to exercise drift's other asymmetric-path case.