### PR TITLE
[dropshot-api-manager-types] rename ApiSpecFileName family to ApiDocFileName

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Every Rust source file must start with:
 
 ### Type system patterns
 
-- **Newtypes** for domain types (e.g., `ApiIdent`, `VcsRevision`, `GitCommitHash`, `ApiSpecFileName`)
+- **Newtypes** for domain types (e.g., `ApiIdent`, `VcsRevision`, `GitCommitHash`, `ApiDocFileName`)
 - **Builder patterns** for complex construction (e.g., `ManagedApi` with `with_extra_validation`, `with_git_stub_storage`)
 - **Type states** encoded in generics when state transitions matter
 - **Lifetimes** used extensively to avoid cloning (e.g., `VersionProblem<'a>`, `Resolution<'a>`, `Fix<'a>`)
@@ -244,7 +244,7 @@ crates/
 ├── dropshot-api-manager-types/    # Core types (minimal deps, for API crates to depend on)
 │   └── src/
 │       ├── lib.rs
-│       ├── apis.rs                # ApiIdent, ApiSpecFileName
+│       ├── apis.rs                # ApiIdent, ApiDocFileName
 │       ├── validation.rs          # ValidationContext, ValidationBackend
 │       └── versions.rs            # Versions, SupportedVersions, api_versions! macro
 └── integration-tests/             # Integration test suite

--- a/crates/dropshot-api-manager-types/src/validation.rs
+++ b/crates/dropshot-api-manager-types/src/validation.rs
@@ -28,7 +28,7 @@ impl<'a> ValidationContext<'a> {
     ///
     /// The file name can be used to identify the version of the API being
     /// validated.
-    pub fn file_name(&self) -> &ApiSpecFileName {
+    pub fn file_name(&self) -> &ApiDocFileName {
         self.backend.file_name()
     }
 
@@ -90,7 +90,7 @@ impl<'a> ValidationContext<'a> {
 #[doc(hidden)]
 pub trait ValidationBackend {
     fn ident(&self) -> &ApiIdent;
-    fn file_name(&self) -> &ApiSpecFileName;
+    fn file_name(&self) -> &ApiDocFileName;
     fn versions(&self) -> &Versions;
     fn is_latest(&self) -> bool;
     fn is_blessed(&self) -> Option<bool>;
@@ -100,17 +100,17 @@ pub trait ValidationBackend {
     fn record_file_contents(&mut self, path: Utf8PathBuf, contents: Vec<u8>);
 }
 
-/// A lockstep API spec filename.
+/// A lockstep API document filename.
 ///
 /// Lockstep APIs have a single OpenAPI document with no versioning. The
 /// filename is simply `{ident}.json`.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct LockstepApiSpecFileName {
+pub struct LockstepApiDocFileName {
     ident: ApiIdent,
 }
 
-impl LockstepApiSpecFileName {
-    /// Creates a new lockstep API spec filename.
+impl LockstepApiDocFileName {
+    /// Creates a new lockstep API document filename.
     pub fn new(ident: ApiIdent) -> Self {
         Self { ident }
     }
@@ -132,43 +132,43 @@ impl LockstepApiSpecFileName {
     }
 }
 
-impl fmt::Display for LockstepApiSpecFileName {
+impl fmt::Display for LockstepApiDocFileName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For lockstep files, path == basename (no directory prefix).
         f.write_str(&self.basename())
     }
 }
 
-/// A versioned API spec filename.
+/// A versioned API document filename.
 ///
 /// Versioned APIs can have multiple versions coexisting. The filename includes
 /// the version and a content hash: `{ident}/{ident}-{version}-{hash}.json` (or
 /// `.json.gitstub` for Git stub storage).
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct VersionedApiSpecFileName {
+pub struct VersionedApiDocFileName {
     ident: ApiIdent,
     version: semver::Version,
     hash: String,
-    kind: VersionedApiSpecKind,
+    kind: VersionedApiDocKind,
 }
 
-impl VersionedApiSpecFileName {
-    /// Creates a new versioned API spec filename (JSON format).
+impl VersionedApiDocFileName {
+    /// Creates a new versioned API document filename (JSON format).
     pub fn new(
         ident: ApiIdent,
         version: semver::Version,
         hash: String,
     ) -> Self {
-        Self { ident, version, hash, kind: VersionedApiSpecKind::Json }
+        Self { ident, version, hash, kind: VersionedApiDocKind::Json }
     }
 
-    /// Creates a new versioned API spec filename (Git stub format).
+    /// Creates a new versioned API document filename (Git stub format).
     pub fn new_git_stub(
         ident: ApiIdent,
         version: semver::Version,
         hash: String,
     ) -> Self {
-        Self { ident, version, hash, kind: VersionedApiSpecKind::GitStub }
+        Self { ident, version, hash, kind: VersionedApiDocKind::GitStub }
     }
 
     /// Returns the API identifier.
@@ -187,13 +187,13 @@ impl VersionedApiSpecFileName {
     }
 
     /// Returns the storage kind (JSON or Git stub).
-    pub fn kind(&self) -> VersionedApiSpecKind {
+    pub fn kind(&self) -> VersionedApiDocKind {
         self.kind
     }
 
     /// Returns true if this is a Git stub.
     pub fn is_git_stub(&self) -> bool {
-        self.kind == VersionedApiSpecKind::GitStub
+        self.kind == VersionedApiDocKind::GitStub
     }
 
     /// Returns the path of this file relative to the root of the OpenAPI
@@ -208,12 +208,12 @@ impl VersionedApiSpecFileName {
     }
 
     /// Returns the base name for a specific storage kind.
-    fn basename_for_kind(&self, kind: VersionedApiSpecKind) -> String {
+    fn basename_for_kind(&self, kind: VersionedApiDocKind) -> String {
         match kind {
-            VersionedApiSpecKind::Json => {
+            VersionedApiDocKind::Json => {
                 format!("{}-{}-{}.json", self.ident, self.version, self.hash)
             }
-            VersionedApiSpecKind::GitStub => {
+            VersionedApiDocKind::GitStub => {
                 format!(
                     "{}-{}-{}.json.gitstub",
                     self.ident, self.version, self.hash
@@ -223,7 +223,7 @@ impl VersionedApiSpecFileName {
     }
 
     /// Returns a copy of this filename with the given storage kind.
-    fn with_kind(&self, kind: VersionedApiSpecKind) -> Self {
+    fn with_kind(&self, kind: VersionedApiDocKind) -> Self {
         Self {
             ident: self.ident.clone(),
             version: self.version.clone(),
@@ -236,14 +236,14 @@ impl VersionedApiSpecFileName {
     ///
     /// If already JSON, returns a clone of self.
     pub fn to_json(&self) -> Self {
-        self.with_kind(VersionedApiSpecKind::Json)
+        self.with_kind(VersionedApiDocKind::Json)
     }
 
     /// Converts this filename to its Git stub equivalent.
     ///
     /// If already a Git stub, returns a clone of self.
     pub fn to_git_stub(&self) -> Self {
-        self.with_kind(VersionedApiSpecKind::GitStub)
+        self.with_kind(VersionedApiDocKind::GitStub)
     }
 
     /// Returns the basename as a Git stubname.
@@ -251,7 +251,7 @@ impl VersionedApiSpecFileName {
     /// - If already a Git stub, returns `basename()` directly.
     /// - If JSON, returns `basename() + ".gitstub"`.
     pub fn git_stub_basename(&self) -> String {
-        self.basename_for_kind(VersionedApiSpecKind::GitStub)
+        self.basename_for_kind(VersionedApiDocKind::GitStub)
     }
 
     /// Returns the basename as a JSON filename.
@@ -259,23 +259,24 @@ impl VersionedApiSpecFileName {
     /// - If already JSON, returns `basename()` directly.
     /// - If Git stub, returns the basename without `.gitstub`.
     pub fn json_basename(&self) -> String {
-        self.basename_for_kind(VersionedApiSpecKind::Json)
+        self.basename_for_kind(VersionedApiDocKind::Json)
     }
 }
 
-impl fmt::Display for VersionedApiSpecFileName {
+impl fmt::Display for VersionedApiDocFileName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // path = "{ident}/{basename}".
         write!(f, "{}/{}", self.ident, self.basename())
     }
 }
 
-/// Describes how a versioned API spec file is stored.
+/// Describes how a versioned API document file is stored.
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub enum VersionedApiSpecKind {
-    /// The spec is stored as a JSON file containing the full OpenAPI document.
+pub enum VersionedApiDocKind {
+    /// The document is stored as a JSON file containing the full OpenAPI
+    /// document.
     Json,
-    /// The spec is stored as a Git stub.
+    /// The document is stored as a Git stub.
     ///
     /// Instead of storing the full JSON content, a `.gitstub` file contains a
     /// reference in the format `commit:path` that can be used to retrieve the
@@ -286,28 +287,28 @@ pub enum VersionedApiSpecKind {
 /// Describes the path to an OpenAPI document file, relative to some root where
 /// similar documents are found.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub enum ApiSpecFileName {
+pub enum ApiDocFileName {
     /// A lockstep API: single OpenAPI document, no versioning.
-    Lockstep(LockstepApiSpecFileName),
+    Lockstep(LockstepApiDocFileName),
     /// A versioned API: multiple versions can coexist.
-    Versioned(VersionedApiSpecFileName),
+    Versioned(VersionedApiDocFileName),
 }
 
-impl fmt::Display for ApiSpecFileName {
+impl fmt::Display for ApiDocFileName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ApiSpecFileName::Lockstep(l) => fmt::Display::fmt(l, f),
-            ApiSpecFileName::Versioned(v) => fmt::Display::fmt(v, f),
+            ApiDocFileName::Lockstep(l) => fmt::Display::fmt(l, f),
+            ApiDocFileName::Versioned(v) => fmt::Display::fmt(v, f),
         }
     }
 }
 
-impl ApiSpecFileName {
+impl ApiDocFileName {
     /// Returns the API identifier.
     pub fn ident(&self) -> &ApiIdent {
         match self {
-            ApiSpecFileName::Lockstep(l) => l.ident(),
-            ApiSpecFileName::Versioned(v) => v.ident(),
+            ApiDocFileName::Lockstep(l) => l.ident(),
+            ApiDocFileName::Versioned(v) => v.ident(),
         }
     }
 
@@ -315,59 +316,59 @@ impl ApiSpecFileName {
     /// documents.
     pub fn path(&self) -> Utf8PathBuf {
         match self {
-            ApiSpecFileName::Lockstep(l) => l.path(),
-            ApiSpecFileName::Versioned(v) => v.path(),
+            ApiDocFileName::Lockstep(l) => l.path(),
+            ApiDocFileName::Versioned(v) => v.path(),
         }
     }
 
     /// Returns the base name of this file path.
     pub fn basename(&self) -> String {
         match self {
-            ApiSpecFileName::Lockstep(l) => l.basename(),
-            ApiSpecFileName::Versioned(v) => v.basename(),
+            ApiDocFileName::Lockstep(l) => l.basename(),
+            ApiDocFileName::Versioned(v) => v.basename(),
         }
     }
 
     /// For versioned APIs, returns the version part of the filename.
     pub fn version(&self) -> Option<&semver::Version> {
         match self {
-            ApiSpecFileName::Lockstep(_) => None,
-            ApiSpecFileName::Versioned(v) => Some(v.version()),
+            ApiDocFileName::Lockstep(_) => None,
+            ApiDocFileName::Versioned(v) => Some(v.version()),
         }
     }
 
     /// For versioned APIs, returns the hash part of the filename.
     pub fn hash(&self) -> Option<&str> {
         match self {
-            ApiSpecFileName::Lockstep(_) => None,
-            ApiSpecFileName::Versioned(v) => Some(v.hash()),
+            ApiDocFileName::Lockstep(_) => None,
+            ApiDocFileName::Versioned(v) => Some(v.hash()),
         }
     }
 
     /// Returns true if this is a Git stub.
     pub fn is_git_stub(&self) -> bool {
         match self {
-            ApiSpecFileName::Lockstep(_) => false,
-            ApiSpecFileName::Versioned(v) => v.is_git_stub(),
+            ApiDocFileName::Lockstep(_) => false,
+            ApiDocFileName::Versioned(v) => v.is_git_stub(),
         }
     }
 
     /// For versioned APIs, returns the kind of storage.
-    pub fn versioned_kind(&self) -> Option<VersionedApiSpecKind> {
+    pub fn versioned_kind(&self) -> Option<VersionedApiDocKind> {
         match self {
-            ApiSpecFileName::Lockstep(_) => None,
-            ApiSpecFileName::Versioned(v) => Some(v.kind()),
+            ApiDocFileName::Lockstep(_) => None,
+            ApiDocFileName::Versioned(v) => Some(v.kind()),
         }
     }
 
     /// Converts a Git stubname to its JSON equivalent.
     ///
     /// For non-Git stubs, returns a clone of self.
-    pub fn to_json_filename(&self) -> ApiSpecFileName {
+    pub fn to_json_filename(&self) -> ApiDocFileName {
         match self {
-            ApiSpecFileName::Lockstep(_) => self.clone(),
-            ApiSpecFileName::Versioned(v) => {
-                ApiSpecFileName::Versioned(v.to_json())
+            ApiDocFileName::Lockstep(_) => self.clone(),
+            ApiDocFileName::Versioned(v) => {
+                ApiDocFileName::Versioned(v.to_json())
             }
         }
     }
@@ -377,11 +378,11 @@ impl ApiSpecFileName {
     /// For Git stubs, returns a clone of self.
     /// For lockstep files, returns a clone of self (lockstep files are not
     /// converted to Git stubs).
-    pub fn to_git_stub_filename(&self) -> ApiSpecFileName {
+    pub fn to_git_stub_filename(&self) -> ApiDocFileName {
         match self {
-            ApiSpecFileName::Lockstep(_) => self.clone(),
-            ApiSpecFileName::Versioned(v) => {
-                ApiSpecFileName::Versioned(v.to_git_stub())
+            ApiDocFileName::Lockstep(_) => self.clone(),
+            ApiDocFileName::Versioned(v) => {
+                ApiDocFileName::Versioned(v.to_git_stub())
             }
         }
     }
@@ -394,8 +395,8 @@ impl ApiSpecFileName {
     ///   to Git stubs).
     pub fn git_stub_basename(&self) -> String {
         match self {
-            ApiSpecFileName::Lockstep(l) => l.basename(),
-            ApiSpecFileName::Versioned(v) => v.git_stub_basename(),
+            ApiDocFileName::Lockstep(l) => l.basename(),
+            ApiDocFileName::Versioned(v) => v.git_stub_basename(),
         }
     }
 
@@ -406,57 +407,57 @@ impl ApiSpecFileName {
     /// - Otherwise, returns `basename()` directly.
     pub fn json_basename(&self) -> String {
         match self {
-            ApiSpecFileName::Lockstep(l) => l.basename(),
-            ApiSpecFileName::Versioned(v) => v.json_basename(),
+            ApiDocFileName::Lockstep(l) => l.basename(),
+            ApiDocFileName::Versioned(v) => v.json_basename(),
         }
     }
 
-    /// Returns a reference to the inner `VersionedApiSpecFileName` if this is
+    /// Returns a reference to the inner `VersionedApiDocFileName` if this is
     /// a versioned API, or `None` if this is a lockstep API.
-    pub fn as_versioned(&self) -> Option<&VersionedApiSpecFileName> {
+    pub fn as_versioned(&self) -> Option<&VersionedApiDocFileName> {
         match self {
-            ApiSpecFileName::Lockstep(_) => None,
-            ApiSpecFileName::Versioned(v) => Some(v),
+            ApiDocFileName::Lockstep(_) => None,
+            ApiDocFileName::Versioned(v) => Some(v),
         }
     }
 
-    /// Consumes `self` and returns the inner `VersionedApiSpecFileName` if
+    /// Consumes `self` and returns the inner `VersionedApiDocFileName` if
     /// this is a versioned API, or `None` if this is a lockstep API.
-    pub fn into_versioned(self) -> Option<VersionedApiSpecFileName> {
+    pub fn into_versioned(self) -> Option<VersionedApiDocFileName> {
         match self {
-            ApiSpecFileName::Lockstep(_) => None,
-            ApiSpecFileName::Versioned(v) => Some(v),
+            ApiDocFileName::Lockstep(_) => None,
+            ApiDocFileName::Versioned(v) => Some(v),
         }
     }
 
-    /// Returns a reference to the inner `LockstepApiSpecFileName` if this is
+    /// Returns a reference to the inner `LockstepApiDocFileName` if this is
     /// a lockstep API, or `None` if this is a versioned API.
-    pub fn as_lockstep(&self) -> Option<&LockstepApiSpecFileName> {
+    pub fn as_lockstep(&self) -> Option<&LockstepApiDocFileName> {
         match self {
-            ApiSpecFileName::Lockstep(l) => Some(l),
-            ApiSpecFileName::Versioned(_) => None,
+            ApiDocFileName::Lockstep(l) => Some(l),
+            ApiDocFileName::Versioned(_) => None,
         }
     }
 
-    /// Consumes `self` and returns the inner `LockstepApiSpecFileName` if
+    /// Consumes `self` and returns the inner `LockstepApiDocFileName` if
     /// this is a lockstep API, or `None` if this is a versioned API.
-    pub fn into_lockstep(self) -> Option<LockstepApiSpecFileName> {
+    pub fn into_lockstep(self) -> Option<LockstepApiDocFileName> {
         match self {
-            ApiSpecFileName::Lockstep(l) => Some(l),
-            ApiSpecFileName::Versioned(_) => None,
+            ApiDocFileName::Lockstep(l) => Some(l),
+            ApiDocFileName::Versioned(_) => None,
         }
     }
 }
 
-impl From<LockstepApiSpecFileName> for ApiSpecFileName {
-    fn from(l: LockstepApiSpecFileName) -> Self {
-        ApiSpecFileName::Lockstep(l)
+impl From<LockstepApiDocFileName> for ApiDocFileName {
+    fn from(l: LockstepApiDocFileName) -> Self {
+        ApiDocFileName::Lockstep(l)
     }
 }
 
-impl From<VersionedApiSpecFileName> for ApiSpecFileName {
-    fn from(v: VersionedApiSpecFileName) -> Self {
-        ApiSpecFileName::Versioned(v)
+impl From<VersionedApiDocFileName> for ApiDocFileName {
+    fn from(v: VersionedApiDocFileName) -> Self {
+        ApiDocFileName::Versioned(v)
     }
 }
 

--- a/crates/dropshot-api-manager/src/resolved.rs
+++ b/crates/dropshot-api-manager/src/resolved.rs
@@ -22,7 +22,7 @@ use crate::{
 use anyhow::{Context, anyhow};
 use camino::{Utf8Path, Utf8PathBuf};
 use dropshot_api_manager_types::{
-    ApiIdent, ApiSpecFileName, VersionedApiSpecFileName,
+    ApiDocFileName, ApiIdent, VersionedApiDocFileName,
 };
 use git_stub::{GitCommitHash, GitStub};
 use rayon::prelude::*;
@@ -231,7 +231,7 @@ pub enum NonVersionProblem<'a> {
          merged with upstream and had to change your local version number.  \
          In either case, this tool can remove the unused file for you."
     )]
-    LocalSpecFileOrphaned { spec_file_name: VersionedApiSpecFileName },
+    LocalSpecFileOrphaned { spec_file_name: VersionedApiDocFileName },
 
     #[error(
         "A local OpenAPI document could not be parsed: {}. \
@@ -243,10 +243,7 @@ pub enum NonVersionProblem<'a> {
     UnparseableLocalFile { unparseable_file: UnparseableFile },
 
     #[error("\"Latest\" symlink for versioned API {api_ident:?} is missing")]
-    LatestLinkMissing {
-        api_ident: ApiIdent,
-        link: &'a VersionedApiSpecFileName,
-    },
+    LatestLinkMissing { api_ident: ApiIdent, link: &'a VersionedApiDocFileName },
 
     #[error(
         "\"Latest\" symlink for versioned API {api_ident:?} is stale: points \
@@ -256,8 +253,8 @@ pub enum NonVersionProblem<'a> {
     )]
     LatestLinkStale {
         api_ident: ApiIdent,
-        found: &'a VersionedApiSpecFileName,
-        link: &'a VersionedApiSpecFileName,
+        found: &'a VersionedApiDocFileName,
+        link: &'a VersionedApiDocFileName,
     },
 }
 
@@ -288,7 +285,7 @@ pub enum VersionProblem<'a> {
          number (when you merged the list of supported versions in Rust) and \
          this file is vestigial. This tool can remove the unused file for you."
     )]
-    BlessedVersionExtraLocalSpec { spec_file_name: VersionedApiSpecFileName },
+    BlessedVersionExtraLocalSpec { spec_file_name: VersionedApiDocFileName },
 
     #[error(
         "error comparing OpenAPI document generated from current code with \
@@ -346,7 +343,7 @@ pub enum VersionProblem<'a> {
          version: {spec_file_names}.  This tool can remove the files for you."
     )]
     LocalVersionExtra {
-        spec_file_names: DisplayableVec<VersionedApiSpecFileName>,
+        spec_file_names: DisplayableVec<VersionedApiDocFileName>,
     },
 
     #[error(
@@ -447,7 +444,7 @@ pub enum VersionProblem<'a> {
          // <source>".
     )]
     GitStubFirstCommitUnknown {
-        spec_file_name: VersionedApiSpecFileName,
+        spec_file_name: VersionedApiDocFileName,
         #[source]
         source: anyhow::Error,
     },
@@ -681,13 +678,13 @@ impl<'a> VersionProblem<'a> {
 
 pub enum Fix<'a> {
     DeleteFiles {
-        files: DisplayableVec<ApiSpecFileName>,
+        files: DisplayableVec<ApiDocFileName>,
     },
     UpdateLockstepFile {
         generated: &'a GeneratedApiSpecFile,
     },
     UpdateVersionedFiles {
-        old: DisplayableVec<&'a ApiSpecFileName>,
+        old: DisplayableVec<&'a ApiDocFileName>,
         generated: &'a GeneratedApiSpecFile,
     },
     UpdateExtraFile {
@@ -696,7 +693,7 @@ pub enum Fix<'a> {
     },
     UpdateSymlink {
         api_ident: &'a ApiIdent,
-        link: &'a VersionedApiSpecFileName,
+        link: &'a VersionedApiDocFileName,
     },
     /// Convert a full JSON file to a Git stub.
     ConvertToGitStub {
@@ -1437,7 +1434,7 @@ fn resolve_orphaned_local_specs<'a>(
         BTreeSet<&'a semver::Version>,
     >,
     local: &'a LocalFiles,
-) -> impl Iterator<Item = &'a VersionedApiSpecFileName> + 'a {
+) -> impl Iterator<Item = &'a VersionedApiDocFileName> + 'a {
     // Orphaned specs are always versioned: lockstep APIs have exactly one file,
     // so orphans can't exist for them.
     local.iter().flat_map(|(ident, api_files)| {

--- a/crates/dropshot-api-manager/src/spec_files_blessed.rs
+++ b/crates/dropshot-api-manager/src/spec_files_blessed.rs
@@ -16,7 +16,7 @@ use crate::{
 use anyhow::{anyhow, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use dropshot_api_manager_types::{
-    ApiIdent, ApiSpecFileName, VersionedApiSpecFileName,
+    ApiDocFileName, ApiIdent, VersionedApiDocFileName,
 };
 use git_stub::{GitCommitHash, GitStub};
 use rayon::prelude::*;
@@ -35,7 +35,7 @@ use std::{collections::BTreeMap, ops::Deref};
 pub struct BlessedApiSpecFile {
     inner: ApiSpecFile,
     /// Cached versioned filename, avoiding repeated conversion.
-    versioned_name: VersionedApiSpecFileName,
+    versioned_name: VersionedApiDocFileName,
 }
 
 impl std::fmt::Debug for BlessedApiSpecFile {
@@ -77,10 +77,10 @@ impl BlessedApiSpecFile {
 
     /// Returns the versioned spec file name.
     ///
-    /// Unlike `spec_file_name()` which returns `&ApiSpecFileName`, this method
-    /// returns the more specific `&VersionedApiSpecFileName` since blessed
+    /// Unlike `spec_file_name()` which returns `&ApiDocFileName`, this method
+    /// returns the more specific `&VersionedApiDocFileName` since blessed
     /// files are always versioned.
-    pub fn versioned_spec_file_name(&self) -> &VersionedApiSpecFileName {
+    pub fn versioned_spec_file_name(&self) -> &VersionedApiDocFileName {
         &self.versioned_name
     }
 }
@@ -109,7 +109,7 @@ impl ApiLoad for BlessedApiSpecFile {
     }
 
     fn make_unparseable(
-        _name: ApiSpecFileName,
+        _name: ApiDocFileName,
         _contents: Vec<u8>,
     ) -> Option<Self::Unparseable> {
         None
@@ -368,7 +368,7 @@ fn process_blessed_entry(
             let Some(spec_file_name) =
                 parse_versioned_file_name(apis, api_dir, basename)
                     .ok()
-                    .map(ApiSpecFileName::from)
+                    .map(ApiDocFileName::from)
             else {
                 return BlessedFileResult::VersionedParseFailed {
                     api_dir: api_dir.to_owned(),
@@ -400,7 +400,7 @@ fn process_blessed_entry(
             let Some(spec_file_name) =
                 parse_versioned_git_stub_file_name(apis, api_dir, basename)
                     .ok()
-                    .map(ApiSpecFileName::from)
+                    .map(ApiDocFileName::from)
             else {
                 return BlessedFileResult::GitStubParseFailed {
                     api_dir: api_dir.to_owned(),

--- a/crates/dropshot-api-manager/src/spec_files_generated.rs
+++ b/crates/dropshot-api-manager/src/spec_files_generated.rs
@@ -13,8 +13,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use dropshot_api_manager_types::{
-    ApiIdent, ApiSpecFileName, LockstepApiSpecFileName,
-    VersionedApiSpecFileName,
+    ApiDocFileName, ApiIdent, LockstepApiDocFileName, VersionedApiDocFileName,
 };
 use rayon::prelude::*;
 use std::{collections::BTreeMap, ops::Deref};
@@ -54,7 +53,7 @@ impl ApiLoad for GeneratedApiSpecFile {
     }
 
     fn make_unparseable(
-        _name: ApiSpecFileName,
+        _name: ApiDocFileName,
         _contents: Vec<u8>,
     ) -> Option<Self::Unparseable> {
         None
@@ -103,7 +102,7 @@ enum GeneratedApiResult {
     Versioned {
         ident: ApiIdent,
         versions: Vec<Result<ApiSpecFile, anyhow::Error>>,
-        latest: Option<VersionedApiSpecFileName>,
+        latest: Option<VersionedApiDocFileName>,
     },
 }
 
@@ -118,7 +117,7 @@ fn generate_api(api: &ManagedApi) -> GeneratedApiResult {
                 api.generate_spec_bytes(version)
                     .and_then(|contents| {
                         let file_name =
-                            LockstepApiSpecFileName::new(api.ident().clone());
+                            LockstepApiDocFileName::new(api.ident().clone());
                         ApiSpecFile::for_contents(file_name.into(), contents)
                             .map_err(|(e, _buf)| e)
                     })
@@ -146,7 +145,7 @@ fn generate_api(api: &ManagedApi) -> GeneratedApiResult {
                 let version = supported_version.semver();
                 api.generate_spec_bytes(version)
                     .and_then(|contents| {
-                        let file_name = VersionedApiSpecFileName::new(
+                        let file_name = VersionedApiDocFileName::new(
                             api.ident().clone(),
                             version.clone(),
                             hash_contents(&contents),
@@ -170,8 +169,8 @@ fn generate_api(api: &ManagedApi) -> GeneratedApiResult {
         // (Note that ParallelIterator::map does not reorder items.)
         let latest = versions.iter().rev().find_map(|r| {
             r.as_ref().ok().map(|file| match file.spec_file_name() {
-                ApiSpecFileName::Versioned(v) => v.clone(),
-                ApiSpecFileName::Lockstep(_) => {
+                ApiDocFileName::Versioned(v) => v.clone(),
+                ApiDocFileName::Lockstep(_) => {
                     unreachable!("lockstep file name in versioned API path")
                 }
             })

--- a/crates/dropshot-api-manager/src/spec_files_generic.rs
+++ b/crates/dropshot-api-manager/src/spec_files_generic.rs
@@ -8,8 +8,8 @@ use anyhow::anyhow;
 use camino::{Utf8Path, Utf8PathBuf};
 use debug_ignore::DebugIgnore;
 use dropshot_api_manager_types::{
-    ApiIdent, ApiSpecFileName, LockstepApiSpecFileName,
-    VersionedApiSpecFileName, VersionedApiSpecKind,
+    ApiDocFileName, ApiIdent, LockstepApiDocFileName, VersionedApiDocFileName,
+    VersionedApiDocKind,
 };
 use git_stub::GitCommitHash;
 use openapiv3::OpenAPI;
@@ -42,14 +42,14 @@ pub struct UnparseableFile {
     pub path: Utf8PathBuf,
 }
 
-/// Attempts to parse the given file basename as a `VersionedApiSpecFileName`.
+/// Attempts to parse the given file basename as a `VersionedApiDocFileName`.
 ///
 /// These look like: `ident-SEMVER-HASH.json`.
 pub(crate) fn parse_versioned_file_name(
     apis: &ManagedApis,
     ident: &str,
     basename: &str,
-) -> Result<VersionedApiSpecFileName, BadVersionedFileName> {
+) -> Result<VersionedApiDocFileName, BadVersionedFileName> {
     let ident = ApiIdent::from(ident.to_string());
     let Some(api) = apis.api(&ident) else {
         return Err(BadVersionedFileName::NoSuchApi);
@@ -116,10 +116,10 @@ pub(crate) fn parse_versioned_file_name(
         });
     }
 
-    Ok(VersionedApiSpecFileName::new(ident, version, hash.to_string()))
+    Ok(VersionedApiDocFileName::new(ident, version, hash.to_string()))
 }
 
-/// Attempts to parse the given file basename as a `VersionedApiSpecFileName`
+/// Attempts to parse the given file basename as a `VersionedApiDocFileName`
 /// with Git stub storage.
 ///
 /// These look like: `ident-SEMVER-HASH.json.gitstub`.
@@ -127,7 +127,7 @@ pub(crate) fn parse_versioned_git_stub_file_name(
     apis: &ManagedApis,
     ident: &str,
     basename: &str,
-) -> Result<VersionedApiSpecFileName, BadVersionedFileName> {
+) -> Result<VersionedApiDocFileName, BadVersionedFileName> {
     // The file name must end with .json.gitstub.
     let json_basename = basename.strip_suffix(".gitstub").ok_or_else(|| {
         BadVersionedFileName::UnexpectedName {
@@ -143,11 +143,11 @@ pub(crate) fn parse_versioned_git_stub_file_name(
     Ok(versioned.to_git_stub())
 }
 
-/// Attempts to parse the given file basename as a `LockstepApiSpecFileName`.
+/// Attempts to parse the given file basename as a `LockstepApiDocFileName`.
 pub(crate) fn parse_lockstep_file_name(
     apis: &ManagedApis,
     basename: &str,
-) -> Result<LockstepApiSpecFileName, BadLockstepFileName> {
+) -> Result<LockstepApiDocFileName, BadLockstepFileName> {
     let ident = ApiIdent::from(
         basename
             .strip_suffix(".json")
@@ -161,7 +161,7 @@ pub(crate) fn parse_lockstep_file_name(
         return Err(BadLockstepFileName::NotLockstep);
     }
 
-    Ok(LockstepApiSpecFileName::new(ident))
+    Ok(LockstepApiDocFileName::new(ident))
 }
 
 /// Describes a failure to parse a file name for a lockstep API.
@@ -220,7 +220,7 @@ enum ApiSpecFileParseError {
 #[derive(Debug)]
 pub struct ApiSpecFile {
     /// describes how the document should be named on disk
-    name: ApiSpecFileName,
+    name: ApiDocFileName,
     /// serde_json::Value representation of the document
     value: DebugIgnore<serde_json::Value>,
     /// parsed contents of the document
@@ -238,7 +238,7 @@ impl ApiSpecFile {
     /// that callers can still use the contents (e.g., for unparseable file
     /// tracking).
     pub fn for_contents(
-        spec_file_name: ApiSpecFileName,
+        spec_file_name: ApiDocFileName,
         contents_buf: Vec<u8>,
     ) -> Result<ApiSpecFile, (anyhow::Error, Vec<u8>)> {
         Self::for_contents_inner(spec_file_name, contents_buf)
@@ -246,7 +246,7 @@ impl ApiSpecFile {
     }
 
     fn for_contents_inner(
-        spec_file_name: ApiSpecFileName,
+        spec_file_name: ApiDocFileName,
         contents_buf: Vec<u8>,
     ) -> Result<ApiSpecFile, (ApiSpecFileParseError, Vec<u8>)> {
         // Parse a serde_json::Value from the contents buffer.
@@ -294,7 +294,7 @@ impl ApiSpecFile {
         };
 
         match &spec_file_name {
-            ApiSpecFileName::Versioned(v) => {
+            ApiDocFileName::Versioned(v) => {
                 if *v.version() != parsed_version {
                     return Err((
                         ApiSpecFileParseError::VersionMismatch {
@@ -307,7 +307,7 @@ impl ApiSpecFile {
 
                 // Only check hash for JSON files. Git stubs use the Git
                 // stub itself as the source of truth.
-                if v.kind() == VersionedApiSpecKind::Json {
+                if v.kind() == VersionedApiDocKind::Json {
                     let expected_hash = hash_contents(&contents_buf);
                     if expected_hash != v.hash() {
                         return Err((
@@ -321,7 +321,7 @@ impl ApiSpecFile {
                     }
                 }
             }
-            ApiSpecFileName::Lockstep(_) => {}
+            ApiDocFileName::Lockstep(_) => {}
         }
 
         Ok(ApiSpecFile {
@@ -334,7 +334,7 @@ impl ApiSpecFile {
     }
 
     /// Returns the name of the OpenAPI document
-    pub fn spec_file_name(&self) -> &ApiSpecFileName {
+    pub fn spec_file_name(&self) -> &ApiDocFileName {
         &self.name
     }
 
@@ -435,7 +435,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         self.error_accumulator.warning(error);
     }
 
-    /// Returns an `ApiSpecFileName` for the given lockstep API.
+    /// Returns an `ApiDocFileName` for the given lockstep API.
     ///
     /// On success, this does not load anything into `self`.  Callers generally
     /// invoke `load_parsed()` with the returned value.  On failure, warnings
@@ -443,7 +443,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     pub fn lockstep_file_name(
         &mut self,
         basename: &str,
-    ) -> Option<ApiSpecFileName> {
+    ) -> Option<ApiDocFileName> {
         match parse_lockstep_file_name(self.apis, basename) {
             // When we're looking at the blessed files, the caller provides
             // `misconfigurations_okay: true` and we treat these as
@@ -543,7 +543,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         }
     }
 
-    /// Returns an `ApiSpecFileName` for the given versioned API.
+    /// Returns an `ApiDocFileName` for the given versioned API.
     ///
     /// On success, this does not load anything into `self`. Callers generally
     /// parse the contents, then invoke `load_parsed()` or
@@ -553,7 +553,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         &mut self,
         ident: &ApiIdent,
         basename: &str,
-    ) -> Option<ApiSpecFileName> {
+    ) -> Option<ApiDocFileName> {
         self.handle_versioned_parse(
             parse_versioned_file_name(self.apis, ident, basename),
             &format!("file {basename}"),
@@ -562,7 +562,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         .map(Into::into)
     }
 
-    /// Returns an `ApiSpecFileName` for the given versioned Git stub.
+    /// Returns an `ApiDocFileName` for the given versioned Git stub.
     ///
     /// On success, this does not load anything into `self`. Callers generally
     /// parse the contents, then invoke `load_parsed()` or
@@ -572,7 +572,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         &mut self,
         ident: &ApiIdent,
         basename: &str,
-    ) -> Option<ApiSpecFileName> {
+    ) -> Option<ApiDocFileName> {
         self.handle_versioned_parse(
             parse_versioned_git_stub_file_name(self.apis, ident, basename),
             &format!("Git stub {basename}"),
@@ -588,7 +588,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         symlink_path: &Utf8Path,
         ident: &ApiIdent,
         basename: &str,
-    ) -> Option<VersionedApiSpecFileName> {
+    ) -> Option<VersionedApiDocFileName> {
         self.handle_versioned_parse(
             parse_versioned_file_name(self.apis, ident, basename),
             &format!("bad symlink {symlink_path} pointing to {basename}"),
@@ -598,16 +598,16 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
 
     /// Shared error handling for versioned file name parsing.
     ///
-    /// On success, returns the parsed `VersionedApiSpecFileName`. On
+    /// On success, returns the parsed `VersionedApiDocFileName`. On
     /// failure, records a warning or error (depending on the kind of
     /// failure and whether misconfigurations are allowed) and returns
     /// `None`.
     fn handle_versioned_parse(
         &mut self,
-        result: Result<VersionedApiSpecFileName, BadVersionedFileName>,
+        result: Result<VersionedApiDocFileName, BadVersionedFileName>,
         error_label: &str,
         warning_label: &str,
-    ) -> Option<VersionedApiSpecFileName> {
+    ) -> Option<VersionedApiDocFileName> {
         match result {
             Ok(file_name) => Some(file_name),
             Err(
@@ -666,7 +666,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     /// other contexts, the error is recorded.
     pub fn load_maybe_unparseable(
         &mut self,
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
     ) {
         match result {
@@ -690,7 +690,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     /// contexts, the error is recorded.
     pub fn load_unparseable(
         &mut self,
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         contents: Vec<u8>,
         reason: anyhow::Error,
     ) {
@@ -704,7 +704,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     /// contexts, the error is recorded.
     fn insert_unparseable(
         &mut self,
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         contents: Vec<u8>,
         reason: anyhow::Error,
     ) {
@@ -769,7 +769,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     pub fn load_latest_link(
         &mut self,
         ident: &ApiIdent,
-        links_to: VersionedApiSpecFileName,
+        links_to: VersionedApiDocFileName,
     ) {
         let Some(api) = self.apis.api(ident) else {
             let error =
@@ -858,7 +858,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
 #[derive(Debug)]
 pub struct ApiFiles<T> {
     spec_files: BTreeMap<semver::Version, T>,
-    latest_link: Option<VersionedApiSpecFileName>,
+    latest_link: Option<VersionedApiDocFileName>,
     /// Files that exist on disk but couldn't be parsed. These are tracked so
     /// that generate can delete them and create correct files in their place.
     unparseable_files: Vec<UnparseableFile>,
@@ -877,7 +877,7 @@ impl<T: AsRawFiles> ApiFiles<T> {
         &self.spec_files
     }
 
-    pub fn latest_link(&self) -> Option<&VersionedApiSpecFileName> {
+    pub fn latest_link(&self) -> Option<&VersionedApiDocFileName> {
         self.latest_link.as_ref()
     }
 
@@ -893,7 +893,7 @@ impl<T: AsRawFiles> ApiFiles<T> {
 /// being able to access their names.
 pub trait SpecFileInfo {
     /// Returns the spec file name.
-    fn spec_file_name(&self) -> &ApiSpecFileName;
+    fn spec_file_name(&self) -> &ApiDocFileName;
 
     /// Returns the version from the parsed file, if available.
     ///
@@ -904,7 +904,7 @@ pub trait SpecFileInfo {
 }
 
 impl SpecFileInfo for ApiSpecFile {
-    fn spec_file_name(&self) -> &ApiSpecFileName {
+    fn spec_file_name(&self) -> &ApiDocFileName {
         &self.name
     }
 
@@ -977,7 +977,7 @@ pub trait ApiLoad {
     /// allowed in this context, `None` otherwise. When `Self::Unparseable` is
     /// `Infallible`, this always returns `None`.
     fn make_unparseable(
-        name: ApiSpecFileName,
+        name: ApiDocFileName,
         contents: Vec<u8>,
     ) -> Option<Self::Unparseable>;
 
@@ -1035,7 +1035,7 @@ mod tests {
         let name = parse_lockstep_file_name(&apis, "lockstep.json").unwrap();
         assert_eq!(
             name,
-            LockstepApiSpecFileName::new(ApiIdent::from("lockstep".to_owned()))
+            LockstepApiDocFileName::new(ApiIdent::from("lockstep".to_owned()))
         );
     }
 
@@ -1050,7 +1050,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             name,
-            VersionedApiSpecFileName::new(
+            VersionedApiDocFileName::new(
                 ApiIdent::from("versioned".to_owned()),
                 Version::new(1, 2, 3),
                 "feedface".to_owned(),
@@ -1142,7 +1142,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             name,
-            VersionedApiSpecFileName::new_git_stub(
+            VersionedApiDocFileName::new_git_stub(
                 ApiIdent::from("versioned".to_owned()),
                 Version::new(1, 2, 3),
                 "feedface".to_owned(),

--- a/crates/dropshot-api-manager/src/spec_files_local.rs
+++ b/crates/dropshot-api-manager/src/spec_files_local.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use anyhow::{Context, anyhow};
 use camino::{Utf8Path, Utf8PathBuf};
-use dropshot_api_manager_types::{ApiIdent, ApiSpecFileName};
+use dropshot_api_manager_types::{ApiDocFileName, ApiIdent};
 use git_stub::{GitCommitHash, GitStub};
 use rayon::prelude::*;
 use std::{collections::BTreeMap, ops::Deref};
@@ -31,7 +31,7 @@ use std::{collections::BTreeMap, ops::Deref};
 #[derive(Debug)]
 pub struct LocalApiUnparseable {
     /// The parsed filename (contains version and hash info).
-    pub name: ApiSpecFileName,
+    pub name: ApiDocFileName,
     /// The raw file contents that couldn't be parsed.
     pub contents: Vec<u8>,
 }
@@ -60,7 +60,7 @@ pub enum LocalApiSpecFile {
 
 impl LocalApiSpecFile {
     /// Returns the spec file name.
-    pub fn spec_file_name(&self) -> &ApiSpecFileName {
+    pub fn spec_file_name(&self) -> &ApiDocFileName {
         match self {
             Self::Valid { spec, .. } => spec.spec_file_name(),
             Self::Unparseable(u) => &u.name,
@@ -93,7 +93,7 @@ impl LocalApiSpecFile {
 }
 
 impl SpecFileInfo for LocalApiSpecFile {
-    fn spec_file_name(&self) -> &ApiSpecFileName {
+    fn spec_file_name(&self) -> &ApiDocFileName {
         self.spec_file_name()
     }
 
@@ -130,7 +130,7 @@ impl ApiLoad for Vec<LocalApiSpecFile> {
     }
 
     fn make_unparseable(
-        name: ApiSpecFileName,
+        name: ApiDocFileName,
         contents: Vec<u8>,
     ) -> Option<Self::Unparseable> {
         Some(LocalApiUnparseable { name, contents })
@@ -238,22 +238,22 @@ enum LocalDiscoveredEntry {
 enum LocalFileResult {
     // --- Successfully parsed filename + deserialized ---
     LockstepDeserialized {
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
     },
     VersionedDeserialized {
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
     },
     GitStubDeserialized {
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
         commit: GitCommitHash,
     },
 
     // --- Git stub that couldn't be resolved ---
     GitStubUnresolvable {
-        file_name: ApiSpecFileName,
+        file_name: ApiDocFileName,
         original_contents: Vec<u8>,
         reason: anyhow::Error,
     },
@@ -454,7 +454,7 @@ fn process_local_entry(
             let Some(spec_file_name) =
                 parse_lockstep_file_name(apis, &file_name)
                     .ok()
-                    .map(ApiSpecFileName::from)
+                    .map(ApiDocFileName::from)
             else {
                 return LocalFileResult::LockstepParseFailed { file_name };
             };
@@ -482,7 +482,7 @@ fn process_local_entry(
             let Some(spec_file_name) =
                 parse_versioned_file_name(apis, &dir_basename, &file_name)
                     .ok()
-                    .map(ApiSpecFileName::from)
+                    .map(ApiDocFileName::from)
             else {
                 return LocalFileResult::VersionedParseFailed {
                     dir_basename,
@@ -512,7 +512,7 @@ fn process_local_entry(
                 &file_name,
             )
             .ok()
-            .map(ApiSpecFileName::from) else {
+            .map(ApiDocFileName::from) else {
                 return LocalFileResult::GitStubParseFailed {
                     dir_basename,
                     file_name,

--- a/crates/dropshot-api-manager/src/validation.rs
+++ b/crates/dropshot-api-manager/src/validation.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use atomicwrites::AtomicFile;
 use camino::{Utf8Path, Utf8PathBuf};
 use dropshot_api_manager_types::{
-    ApiIdent, ApiSpecFileName, ManagedApiMetadata, ValidationBackend,
+    ApiDocFileName, ApiIdent, ManagedApiMetadata, ValidationBackend,
     ValidationContext, Versions,
 };
 use openapiv3::OpenAPI;
@@ -50,7 +50,7 @@ pub fn validate(
 fn validate_generated_openapi_document(
     api: &ManagedApi,
     openapi_doc: &OpenAPI,
-    file_name: &ApiSpecFileName,
+    file_name: &ApiDocFileName,
     is_latest: bool,
     is_blessed: Option<bool>,
     validation: Option<&DynValidationFn>,
@@ -192,7 +192,7 @@ pub struct ValidationResult {
 
 struct ValidationContextImpl {
     ident: ApiIdent,
-    file_name: ApiSpecFileName,
+    file_name: ApiDocFileName,
     versions: Versions,
     is_latest: bool,
     is_blessed: Option<bool>,
@@ -207,7 +207,7 @@ impl ValidationBackend for ValidationContextImpl {
         &self.ident
     }
 
-    fn file_name(&self) -> &ApiSpecFileName {
+    fn file_name(&self) -> &ApiDocFileName {
         &self.file_name
     }
 


### PR DESCRIPTION
Standardize on OpenAPI "document" terminology.
