### PR TITLE
[dropshot-api-manager] rename internal spec identifiers to doc

### DIFF
--- a/crates/dropshot-api-manager/src/apis.rs
+++ b/crates/dropshot-api-manager/src/apis.rs
@@ -250,12 +250,12 @@ impl ManagedApi {
         // but this is the easiest way to do so (currently, Dropshot doesn't
         // return the OpenAPI type directly). It is also consistent with the
         // other code paths.
-        let contents = self.generate_spec_bytes(version)?;
+        let contents = self.generate_doc_bytes(version)?;
         serde_json::from_slice(&contents)
             .context("generated document is not valid OpenAPI")
     }
 
-    pub(crate) fn generate_spec_bytes(
+    pub(crate) fn generate_doc_bytes(
         &self,
         version: &semver::Version,
     ) -> anyhow::Result<Vec<u8>> {

--- a/crates/dropshot-api-manager/src/cmd/debug.rs
+++ b/crates/dropshot-api-manager/src/cmd/debug.rs
@@ -2,12 +2,12 @@
 
 use crate::{
     apis::ManagedApis,
+    doc_files_generic::{ApiFiles, AsRawFiles},
     environment::{
         BlessedSource, ErrorAccumulator, GeneratedSource, ResolvedEnv,
     },
     output::OutputOpts,
     resolved::Resolved,
-    spec_files_generic::{ApiFiles, AsRawFiles},
 };
 use dropshot_api_manager_types::ApiIdent;
 use std::collections::BTreeMap;
@@ -109,7 +109,7 @@ pub(crate) fn debug_impl(
 }
 
 fn dump_structure<T: AsRawFiles>(
-    spec_files: &BTreeMap<ApiIdent, ApiFiles<T>>,
+    doc_files: &BTreeMap<ApiIdent, ApiFiles<T>>,
     error_accumulator: &ErrorAccumulator,
 ) {
     let warnings: Vec<_> = error_accumulator.iter_warnings().collect();
@@ -124,7 +124,7 @@ fn dump_structure<T: AsRawFiles>(
         println!("    error: {:#}", e);
     }
 
-    for (api_ident, info) in spec_files {
+    for (api_ident, info) in doc_files {
         println!("    API: {}", api_ident);
         println!(
             "        latest: {}",
@@ -135,14 +135,14 @@ fn dump_structure<T: AsRawFiles>(
         );
         for (version, files) in info.versions() {
             println!("        version {}:", version);
-            for api_spec in files.as_raw_files() {
-                let version_str = api_spec
+            for api_doc in files.as_raw_files() {
+                let version_str = api_doc
                     .version()
                     .map(|v| v.to_string())
                     .unwrap_or_else(|| "unparseable".to_string());
                 println!(
                     "            file {} (v{})",
-                    api_spec.spec_file_name().path(),
+                    api_doc.doc_file_name().path(),
                     version_str
                 );
             }

--- a/crates/dropshot-api-manager/src/cmd/generate.rs
+++ b/crates/dropshot-api-manager/src/cmd/generate.rs
@@ -7,7 +7,7 @@ use crate::{
     environment::{BlessedSource, GeneratedSource, ResolvedEnv},
     output::{
         CheckResult, CompatDisplayContext, OutputOpts, Styles,
-        display_api_spec_version, display_load_problems,
+        display_api_doc_version, display_load_problems,
         display_non_version_problems, display_resolution,
         display_version_problems,
         headers::{self, *},
@@ -126,7 +126,7 @@ fn generate_impl_inner(
                     writer,
                     "{:>HEADER_WIDTH$} {}",
                     UNCHANGED.style(styles.unchanged_header),
-                    display_api_spec_version(api, version, styles, resolution),
+                    display_api_doc_version(api, version, styles, resolution),
                 )?;
                 num_unchanged += 1;
             } else {
@@ -134,7 +134,7 @@ fn generate_impl_inner(
                     writer,
                     "{:>HEADER_WIDTH$} {}",
                     STALE.style(styles.warning_header),
-                    display_api_spec_version(api, version, styles, resolution),
+                    display_api_doc_version(api, version, styles, resolution),
                 )?;
 
                 apply_fixes(

--- a/crates/dropshot-api-manager/src/cmd/list.rs
+++ b/crates/dropshot-api-manager/src/cmd/list.rs
@@ -1,8 +1,8 @@
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use crate::{
     apis::ManagedApis,
-    output::{OutputOpts, display_api_spec, display_error, plural},
+    output::{OutputOpts, display_api_doc, display_error, plural},
 };
 use indent_write::io::IndentWriter;
 use openapiv3::OpenAPI;
@@ -138,13 +138,13 @@ pub(crate) fn list_impl(
             }
         }
     } else {
-        for (ix, spec) in apis.iter_apis().enumerate() {
+        for (ix, api) in apis.iter_apis().enumerate() {
             let count = ix + 1;
 
             writeln!(
                 &mut out,
                 "{count:count_width$}) {}",
-                display_api_spec(spec, &styles),
+                display_api_doc(api, &styles),
             )?;
         }
 

--- a/crates/dropshot-api-manager/src/compatibility/detect.rs
+++ b/crates/dropshot-api-manager/src/compatibility/detect.rs
@@ -14,8 +14,8 @@ use drift::{Change, ChangeClass, ChangeInfo, ChangePath};
 
 impl ApiCompatIssue {
     fn new(
-        blessed_spec: &serde_json::Value,
-        generated_spec: &serde_json::Value,
+        blessed_doc: &serde_json::Value,
+        generated_doc: &serde_json::Value,
         paths: Vec<ChangePath>,
         change_infos: Vec<ChangeInfo>,
         blessed_op_ids: &OperationIdMap<'_>,
@@ -43,10 +43,10 @@ impl ApiCompatIssue {
         // the diff renders as plain additions (or deletions) of the one
         // endpoint that actually changed.
         let blessed_value = (!blessed_base.is_paths_root())
-            .then(|| get_json_value(blessed_base_ptr, blessed_spec))
+            .then(|| get_json_value(blessed_base_ptr, blessed_doc))
             .flatten();
         let generated_value = (!generated_base.is_paths_root())
-            .then(|| get_json_value(generated_base_ptr, generated_spec))
+            .then(|| get_json_value(generated_base_ptr, generated_doc))
             .flatten();
 
         let changes =
@@ -266,13 +266,13 @@ fn extract_operation_ids(doc: &serde_json::Value) -> OperationIdMap<'_> {
 
 fn get_json_value(
     pointer: &str,
-    spec: &serde_json::Value,
+    doc: &serde_json::Value,
 ) -> Option<serde_json::Value> {
     // serde_json's JSON Pointer implementation does not accept
     // leading `#`, so strip that.
     let pointer = pointer.trim_start_matches('#');
 
-    spec.pointer(pointer).map(|v| {
+    doc.pointer(pointer).map(|v| {
         // Add a map around the value, with the key being the last
         // component of the pointer.
         let last_component = pointer.split('/').next_back().unwrap_or("");
@@ -537,7 +537,7 @@ mod tests {
     fn test_normalize_already_new_format_is_noop() {
         // Both blessed and generated have the new format — normalization
         // should be a no-op.
-        let mut spec = serde_json::json!({
+        let mut doc = serde_json::json!({
             "paths": {
                 "/subscribe": {
                     "get": {
@@ -555,14 +555,14 @@ mod tests {
             }
         });
 
-        let original = spec.clone();
-        normalize_old_websocket_responses(&mut spec, &original);
-        assert_eq!(spec, original);
+        let original = doc.clone();
+        normalize_old_websocket_responses(&mut doc, &original);
+        assert_eq!(doc, original);
     }
 
     #[test]
     fn test_normalize_no_websocket_endpoints_is_noop() {
-        let mut spec = serde_json::json!({
+        let mut doc = serde_json::json!({
             "paths": {
                 "/health": {
                     "get": {
@@ -573,9 +573,9 @@ mod tests {
             }
         });
 
-        let original = spec.clone();
-        normalize_old_websocket_responses(&mut spec, &original);
-        assert_eq!(spec, original);
+        let original = doc.clone();
+        normalize_old_websocket_responses(&mut doc, &original);
+        assert_eq!(doc, original);
     }
 
     #[test]

--- a/crates/dropshot-api-manager/src/doc_files_blessed.rs
+++ b/crates/dropshot-api-manager/src/doc_files_blessed.rs
@@ -5,12 +5,12 @@
 
 use crate::{
     apis::ManagedApis,
-    environment::ErrorAccumulator,
-    spec_files_generic::{
-        ApiFiles, ApiLoad, ApiSpecFile, ApiSpecFilesBuilder, AsRawFiles,
-        GitStubKey, SpecFileInfo, parse_versioned_file_name,
+    doc_files_generic::{
+        ApiDocFile, ApiDocFilesBuilder, ApiFiles, ApiLoad, AsRawFiles,
+        DocFileInfo, GitStubKey, parse_versioned_file_name,
         parse_versioned_git_stub_file_name,
     },
+    environment::ErrorAccumulator,
     vcs::{RepoVcs, VcsRevision},
 };
 use anyhow::{anyhow, bail};
@@ -22,7 +22,7 @@ use git_stub::{GitCommitHash, GitStub};
 use rayon::prelude::*;
 use std::{collections::BTreeMap, ops::Deref};
 
-/// Newtype wrapper around [`ApiSpecFile`] to describe OpenAPI documents from
+/// Newtype wrapper around [`ApiDocFile`] to describe OpenAPI documents from
 /// the "blessed" source.
 ///
 /// The blessed source contains the documents that are not allowed to be changed
@@ -32,43 +32,41 @@ use std::{collections::BTreeMap, ops::Deref};
 /// don't have a meaningful "blessed" source since they're always regenerated.
 /// The type system enforces this invariant: construction will panic if given a
 /// lockstep spec.
-pub struct BlessedApiSpecFile {
-    inner: ApiSpecFile,
+pub struct BlessedApiDocFile {
+    inner: ApiDocFile,
     /// Cached versioned filename, avoiding repeated conversion.
     versioned_name: VersionedApiDocFileName,
 }
 
-impl std::fmt::Debug for BlessedApiSpecFile {
+impl std::fmt::Debug for BlessedApiDocFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BlessedApiSpecFile")
-            .field("inner", &self.inner)
-            .finish()
+        f.debug_struct("BlessedApiDocFile").field("inner", &self.inner).finish()
     }
 }
 
-impl Deref for BlessedApiSpecFile {
-    type Target = ApiSpecFile;
+impl Deref for BlessedApiDocFile {
+    type Target = ApiDocFile;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl BlessedApiSpecFile {
-    /// Creates a new `BlessedApiSpecFile` from an `ApiSpecFile`.
+impl BlessedApiDocFile {
+    /// Creates a new `BlessedApiDocFile` from an `ApiDocFile`.
     ///
     /// # Panics
     ///
     /// Panics if the spec file is for a lockstep API. Blessed files only exist
     /// for versioned APIs.
-    pub fn new(inner: ApiSpecFile) -> Self {
+    pub fn new(inner: ApiDocFile) -> Self {
         let versioned_name = inner
-            .spec_file_name()
+            .doc_file_name()
             .as_versioned()
             .unwrap_or_else(|| {
                 panic!(
-                    "BlessedApiSpecFile requires a versioned API spec, \
+                    "BlessedApiDocFile requires a versioned API spec, \
                      got lockstep: {}",
-                    inner.spec_file_name()
+                    inner.doc_file_name()
                 )
             })
             .clone();
@@ -77,34 +75,34 @@ impl BlessedApiSpecFile {
 
     /// Returns the versioned spec file name.
     ///
-    /// Unlike `spec_file_name()` which returns `&ApiDocFileName`, this method
+    /// Unlike `doc_file_name()` which returns `&ApiDocFileName`, this method
     /// returns the more specific `&VersionedApiDocFileName` since blessed
     /// files are always versioned.
-    pub fn versioned_spec_file_name(&self) -> &VersionedApiDocFileName {
+    pub fn versioned_doc_file_name(&self) -> &VersionedApiDocFileName {
         &self.versioned_name
     }
 }
 
-// Trait impls that allow us to use `ApiFiles<BlessedApiSpecFile>`
+// Trait impls that allow us to use `ApiFiles<BlessedApiDocFile>`
 //
 // Note that this is NOT a `Vec` because it's NOT allowed to have more than one
-// BlessedApiSpecFile for a given version.
+// BlessedApiDocFile for a given version.
 
-impl ApiLoad for BlessedApiSpecFile {
+impl ApiLoad for BlessedApiDocFile {
     const MISCONFIGURATIONS_ALLOWED: bool = true;
     type Unparseable = std::convert::Infallible;
 
-    fn make_item(raw: ApiSpecFile) -> Self {
-        BlessedApiSpecFile::new(raw)
+    fn make_item(raw: ApiDocFile) -> Self {
+        BlessedApiDocFile::new(raw)
     }
 
-    fn try_extend(&mut self, item: ApiSpecFile) -> anyhow::Result<()> {
+    fn try_extend(&mut self, item: ApiDocFile) -> anyhow::Result<()> {
         // This should be impossible.
         bail!(
             "found more than one blessed OpenAPI document for a given \
              API version: at least {} and {}",
-            self.spec_file_name(),
-            item.spec_file_name()
+            self.doc_file_name(),
+            item.doc_file_name()
         );
     }
 
@@ -124,11 +122,11 @@ impl ApiLoad for BlessedApiSpecFile {
     }
 }
 
-impl AsRawFiles for BlessedApiSpecFile {
+impl AsRawFiles for BlessedApiDocFile {
     fn as_raw_files<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = &'a dyn SpecFileInfo> + 'a> {
-        Box::new(std::iter::once(self.deref() as &dyn SpecFileInfo))
+    ) -> Box<dyn Iterator<Item = &'a dyn DocFileInfo> + 'a> {
+        Box::new(std::iter::once(self.deref() as &dyn DocFileInfo))
     }
 }
 
@@ -257,11 +255,11 @@ impl<'a> BlessedPathKind<'a> {
 /// structure.**
 ///
 /// For more on what's been validated at this point, see
-/// [`ApiSpecFilesBuilder`].
+/// [`ApiDocFilesBuilder`].
 #[derive(Debug)]
 pub struct BlessedFiles {
     /// The loaded blessed files.
-    files: BTreeMap<ApiIdent, ApiFiles<BlessedApiSpecFile>>,
+    files: BTreeMap<ApiIdent, ApiFiles<BlessedApiDocFile>>,
     /// Git stubs for each blessed file, keyed by (ident, version).
     git_stubs: BTreeMap<GitStubKey, BlessedGitStub>,
     /// The merge base used when loading blessed files from VCS history.
@@ -273,7 +271,7 @@ pub struct BlessedFiles {
 }
 
 impl Deref for BlessedFiles {
-    type Target = BTreeMap<ApiIdent, ApiFiles<BlessedApiSpecFile>>;
+    type Target = BTreeMap<ApiIdent, ApiFiles<BlessedApiDocFile>>;
 
     fn deref(&self) -> &Self::Target {
         &self.files
@@ -315,13 +313,13 @@ enum BlessedFileResult {
     /// Read a versioned JSON file from git. The `result` indicates whether
     /// deserialization succeeded.
     VersionedDeserialized {
-        result: Result<ApiSpecFile, anyhow::Error>,
+        result: Result<ApiDocFile, anyhow::Error>,
         git_path: String,
     },
     /// Read a Git stub file and resolved its contents. The `result`
     /// indicates whether deserialization succeeded.
     GitStubDeserialized {
-        result: Result<ApiSpecFile, anyhow::Error>,
+        result: Result<ApiDocFile, anyhow::Error>,
         git_stub: GitStub,
     },
 
@@ -365,7 +363,7 @@ fn process_blessed_entry(
                 return BlessedFileResult::Skip;
             }
 
-            let Some(spec_file_name) =
+            let Some(doc_file_name) =
                 parse_versioned_file_name(apis, api_dir, basename)
                     .ok()
                     .map(ApiDocFileName::from)
@@ -386,9 +384,9 @@ fn process_blessed_entry(
                 };
 
             // Deserialize.
-            let result = ApiSpecFile::for_contents(spec_file_name, contents)
+            let result = ApiDocFile::for_contents(doc_file_name, contents)
                 .map_err(|(err, _bytes)| {
-                    // BlessedApiSpecFile doesn't track unparseable
+                    // BlessedApiDocFile doesn't track unparseable
                     // files, so drop the raw bytes (as _bytes).
                     err
                 });
@@ -397,7 +395,7 @@ fn process_blessed_entry(
         }
 
         BlessedPathKind::GitStubFile { api_dir, basename } => {
-            let Some(spec_file_name) =
+            let Some(doc_file_name) =
                 parse_versioned_git_stub_file_name(apis, api_dir, basename)
                     .ok()
                     .map(ApiDocFileName::from)
@@ -449,9 +447,8 @@ fn process_blessed_entry(
                 };
 
             // Deserialize.
-            let result =
-                ApiSpecFile::for_contents(spec_file_name, json_contents)
-                    .map_err(|(err, _bytes)| err);
+            let result = ApiDocFile::for_contents(doc_file_name, json_contents)
+                .map_err(|(err, _bytes)| err);
 
             BlessedFileResult::GitStubDeserialized { result, git_stub }
         }
@@ -520,8 +517,8 @@ impl BlessedFiles {
             .collect();
 
         // Phase 2 (reduce): build up the internal builder state.
-        let mut api_files: ApiSpecFilesBuilder<BlessedApiSpecFile> =
-            ApiSpecFilesBuilder::new(apis, error_accumulator);
+        let mut api_files: ApiDocFilesBuilder<BlessedApiDocFile> =
+            ApiDocFilesBuilder::new(apis, error_accumulator);
         let mut git_stubs: BTreeMap<GitStubKey, BlessedGitStub> =
             BTreeMap::new();
         // Cache for `versioned_directory()` results to avoid duplicate
@@ -551,7 +548,7 @@ impl BlessedFiles {
                         // when needed (i.e., when Git stub storage is
                         // enabled).
                         let version = file.version().clone();
-                        let ident = file.spec_file_name().ident().clone();
+                        let ident = file.doc_file_name().ident().clone();
                         git_stubs.insert(
                             GitStubKey { ident, version },
                             BlessedGitStub::Lazy {
@@ -571,7 +568,7 @@ impl BlessedFiles {
                             // The Git stub already contains the first
                             // commit, so use it directly.
                             let version = file.version().clone();
-                            let ident = file.spec_file_name().ident().clone();
+                            let ident = file.doc_file_name().ident().clone();
                             git_stubs.insert(
                                 GitStubKey { ident, version },
                                 BlessedGitStub::Known {
@@ -612,8 +609,8 @@ impl BlessedFiles {
     }
 }
 
-impl<'a> From<ApiSpecFilesBuilder<'a, BlessedApiSpecFile>> for BlessedFiles {
-    fn from(api_files: ApiSpecFilesBuilder<'a, BlessedApiSpecFile>) -> Self {
+impl<'a> From<ApiDocFilesBuilder<'a, BlessedApiDocFile>> for BlessedFiles {
+    fn from(api_files: ApiDocFilesBuilder<'a, BlessedApiDocFile>) -> Self {
         // When loading from a directory, we don't have Git stubs or a merge
         // base.
         BlessedFiles {

--- a/crates/dropshot-api-manager/src/doc_files_generated.rs
+++ b/crates/dropshot-api-manager/src/doc_files_generated.rs
@@ -5,11 +5,11 @@
 
 use crate::{
     apis::{ManagedApi, ManagedApis},
-    environment::ErrorAccumulator,
-    spec_files_generic::{
-        ApiFiles, ApiLoad, ApiSpecFile, ApiSpecFilesBuilder, AsRawFiles,
-        SpecFileInfo, hash_contents,
+    doc_files_generic::{
+        ApiDocFile, ApiDocFilesBuilder, ApiFiles, ApiLoad, AsRawFiles,
+        DocFileInfo, hash_contents,
     },
+    environment::ErrorAccumulator,
 };
 use anyhow::{anyhow, bail};
 use dropshot_api_manager_types::{
@@ -18,37 +18,37 @@ use dropshot_api_manager_types::{
 use rayon::prelude::*;
 use std::{collections::BTreeMap, ops::Deref};
 
-/// Newtype wrapper around [`ApiSpecFile`] to describe OpenAPI documents
+/// Newtype wrapper around [`ApiDocFile`] to describe OpenAPI documents
 /// generated from API definitions
 ///
 /// This includes documents for lockstep APIs and versioned APIs, for both
 /// blessed and locally-added versions.
-pub struct GeneratedApiSpecFile(ApiSpecFile);
-NewtypeDebug! { () pub struct GeneratedApiSpecFile(ApiSpecFile); }
-NewtypeDeref! { () pub struct GeneratedApiSpecFile(ApiSpecFile); }
-NewtypeDerefMut! { () pub struct GeneratedApiSpecFile(ApiSpecFile); }
-NewtypeFrom! { () pub struct GeneratedApiSpecFile(ApiSpecFile); }
+pub struct GeneratedApiDocFile(ApiDocFile);
+NewtypeDebug! { () pub struct GeneratedApiDocFile(ApiDocFile); }
+NewtypeDeref! { () pub struct GeneratedApiDocFile(ApiDocFile); }
+NewtypeDerefMut! { () pub struct GeneratedApiDocFile(ApiDocFile); }
+NewtypeFrom! { () pub struct GeneratedApiDocFile(ApiDocFile); }
 
-// Trait impls that allow us to use `ApiFiles<GeneratedApiSpecFile>`
+// Trait impls that allow us to use `ApiFiles<GeneratedApiDocFile>`
 //
 // Note that this is NOT a `Vec` because it's NOT allowed to have more than one
-// GeneratedApiSpecFile for a given version.
+// GeneratedApiDocFile for a given version.
 
-impl ApiLoad for GeneratedApiSpecFile {
+impl ApiLoad for GeneratedApiDocFile {
     const MISCONFIGURATIONS_ALLOWED: bool = false;
     type Unparseable = std::convert::Infallible;
 
-    fn make_item(raw: ApiSpecFile) -> Self {
-        GeneratedApiSpecFile(raw)
+    fn make_item(raw: ApiDocFile) -> Self {
+        GeneratedApiDocFile(raw)
     }
 
-    fn try_extend(&mut self, item: ApiSpecFile) -> anyhow::Result<()> {
+    fn try_extend(&mut self, item: ApiDocFile) -> anyhow::Result<()> {
         // This should be impossible.
         bail!(
             "found more than one generated OpenAPI document for a given \
              API version: at least {} and {}",
-            self.spec_file_name(),
-            item.spec_file_name()
+            self.doc_file_name(),
+            item.doc_file_name()
         );
     }
 
@@ -68,11 +68,11 @@ impl ApiLoad for GeneratedApiSpecFile {
     }
 }
 
-impl AsRawFiles for GeneratedApiSpecFile {
+impl AsRawFiles for GeneratedApiDocFile {
     fn as_raw_files<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = &'a dyn SpecFileInfo> + 'a> {
-        Box::new(std::iter::once(self.deref() as &dyn SpecFileInfo))
+    ) -> Box<dyn Iterator<Item = &'a dyn DocFileInfo> + 'a> {
+        Box::new(std::iter::once(self.deref() as &dyn DocFileInfo))
     }
 }
 
@@ -82,26 +82,26 @@ impl AsRawFiles for GeneratedApiSpecFile {
 /// structure.**
 ///
 /// For more on what's been validated at this point, see
-/// [`ApiSpecFilesBuilder`].
-pub struct GeneratedFiles(BTreeMap<ApiIdent, ApiFiles<GeneratedApiSpecFile>>);
+/// [`ApiDocFilesBuilder`].
+pub struct GeneratedFiles(BTreeMap<ApiIdent, ApiFiles<GeneratedApiDocFile>>);
 NewtypeDeref! {
     () pub struct GeneratedFiles(
-        BTreeMap<ApiIdent, ApiFiles<GeneratedApiSpecFile>>
+        BTreeMap<ApiIdent, ApiFiles<GeneratedApiDocFile>>
     );
 }
 
 /// Intermediate result from generating all versions for a single API.
 ///
 /// This is produced in parallel (one per API) and then fed sequentially
-/// into `ApiSpecFilesBuilder`. Each version is fully deserialized in the
+/// into `ApiDocFilesBuilder`. Each version is fully deserialized in the
 /// parallel phase so that serde work doesn't bottleneck the reduce phase.
 enum GeneratedApiResult {
     Lockstep {
-        versions: Vec<Result<ApiSpecFile, anyhow::Error>>,
+        versions: Vec<Result<ApiDocFile, anyhow::Error>>,
     },
     Versioned {
         ident: ApiIdent,
-        versions: Vec<Result<ApiSpecFile, anyhow::Error>>,
+        versions: Vec<Result<ApiDocFile, anyhow::Error>>,
         latest: Option<VersionedApiDocFileName>,
     },
 }
@@ -114,11 +114,11 @@ fn generate_api(api: &ManagedApi) -> GeneratedApiResult {
         let versions = api
             .iter_versions_semver()
             .map(|version| {
-                api.generate_spec_bytes(version)
+                api.generate_doc_bytes(version)
                     .and_then(|contents| {
                         let file_name =
                             LockstepApiDocFileName::new(api.ident().clone());
-                        ApiSpecFile::for_contents(file_name.into(), contents)
+                        ApiDocFile::for_contents(file_name.into(), contents)
                             .map_err(|(e, _buf)| e)
                     })
                     .map_err(|error| {
@@ -143,14 +143,14 @@ fn generate_api(api: &ManagedApi) -> GeneratedApiResult {
             .par_iter()
             .map(|supported_version| {
                 let version = supported_version.semver();
-                api.generate_spec_bytes(version)
+                api.generate_doc_bytes(version)
                     .and_then(|contents| {
                         let file_name = VersionedApiDocFileName::new(
                             api.ident().clone(),
                             version.clone(),
                             hash_contents(&contents),
                         );
-                        ApiSpecFile::for_contents(file_name.into(), contents)
+                        ApiDocFile::for_contents(file_name.into(), contents)
                             .map_err(|(e, _buf)| e)
                     })
                     .map_err(|error| {
@@ -168,7 +168,7 @@ fn generate_api(api: &ManagedApi) -> GeneratedApiResult {
         //
         // (Note that ParallelIterator::map does not reorder items.)
         let latest = versions.iter().rev().find_map(|r| {
-            r.as_ref().ok().map(|file| match file.spec_file_name() {
+            r.as_ref().ok().map(|file| match file.doc_file_name() {
                 ApiDocFileName::Versioned(v) => v.clone(),
                 ApiDocFileName::Lockstep(_) => {
                     unreachable!("lockstep file name in versioned API path")
@@ -201,8 +201,8 @@ impl GeneratedFiles {
             .collect();
 
         // Reduce: feed results into the builder sequentially.
-        let mut api_files: ApiSpecFilesBuilder<GeneratedApiSpecFile> =
-            ApiSpecFilesBuilder::new(apis, error_accumulator);
+        let mut api_files: ApiDocFilesBuilder<GeneratedApiDocFile> =
+            ApiDocFilesBuilder::new(apis, error_accumulator);
 
         for result in results {
             let (versions, latest_info) = match result {
@@ -235,10 +235,8 @@ impl GeneratedFiles {
     }
 }
 
-impl<'a> From<ApiSpecFilesBuilder<'a, GeneratedApiSpecFile>>
-    for GeneratedFiles
-{
-    fn from(api_files: ApiSpecFilesBuilder<'a, GeneratedApiSpecFile>) -> Self {
+impl<'a> From<ApiDocFilesBuilder<'a, GeneratedApiDocFile>> for GeneratedFiles {
+    fn from(api_files: ApiDocFilesBuilder<'a, GeneratedApiDocFile>) -> Self {
         GeneratedFiles(api_files.into_map())
     }
 }

--- a/crates/dropshot-api-manager/src/doc_files_generic.rs
+++ b/crates/dropshot-api-manager/src/doc_files_generic.rs
@@ -197,7 +197,7 @@ pub(crate) enum BadVersionedFileName {
 
 /// Errors that can occur when parsing an API spec file.
 #[derive(Debug, Error)]
-enum ApiSpecFileParseError {
+enum ApiDocFileParseError {
     #[error("file {path:?}: parsing as JSON")]
     JsonParse { path: Utf8PathBuf, source: serde_json::Error },
     #[error("file {path:?}: parsing OpenAPI document")]
@@ -218,7 +218,7 @@ enum ApiSpecFileParseError {
 
 /// Describes an OpenAPI document
 #[derive(Debug)]
-pub struct ApiSpecFile {
+pub struct ApiDocFile {
     /// describes how the document should be named on disk
     name: ApiDocFileName,
     /// serde_json::Value representation of the document
@@ -231,32 +231,32 @@ pub struct ApiSpecFile {
     version: semver::Version,
 }
 
-impl ApiSpecFile {
+impl ApiDocFile {
     /// Parse an OpenAPI document from raw contents.
     ///
     /// On error, returns both the error and the original contents buffer so
     /// that callers can still use the contents (e.g., for unparseable file
     /// tracking).
     pub fn for_contents(
-        spec_file_name: ApiDocFileName,
+        doc_file_name: ApiDocFileName,
         contents_buf: Vec<u8>,
-    ) -> Result<ApiSpecFile, (anyhow::Error, Vec<u8>)> {
-        Self::for_contents_inner(spec_file_name, contents_buf)
+    ) -> Result<ApiDocFile, (anyhow::Error, Vec<u8>)> {
+        Self::for_contents_inner(doc_file_name, contents_buf)
             .map_err(|(e, buf)| (e.into(), buf))
     }
 
     fn for_contents_inner(
-        spec_file_name: ApiDocFileName,
+        doc_file_name: ApiDocFileName,
         contents_buf: Vec<u8>,
-    ) -> Result<ApiSpecFile, (ApiSpecFileParseError, Vec<u8>)> {
+    ) -> Result<ApiDocFile, (ApiDocFileParseError, Vec<u8>)> {
         // Parse a serde_json::Value from the contents buffer.
         let value: serde_json::Value =
             match serde_json::from_slice(&contents_buf) {
                 Ok(v) => v,
                 Err(e) => {
                     return Err((
-                        ApiSpecFileParseError::JsonParse {
-                            path: spec_file_name.path(),
+                        ApiDocFileParseError::JsonParse {
+                            path: doc_file_name.path(),
                             source: e,
                         },
                         contents_buf,
@@ -270,8 +270,8 @@ impl ApiSpecFile {
             Ok(o) => o,
             Err(e) => {
                 return Err((
-                    ApiSpecFileParseError::OpenApiParse {
-                        path: spec_file_name.path(),
+                    ApiDocFileParseError::OpenApiParse {
+                        path: doc_file_name.path(),
                         source: e,
                     },
                     contents_buf,
@@ -284,8 +284,8 @@ impl ApiSpecFile {
             Ok(v) => v,
             Err(e) => {
                 return Err((
-                    ApiSpecFileParseError::VersionParse {
-                        path: spec_file_name.path(),
+                    ApiDocFileParseError::VersionParse {
+                        path: doc_file_name.path(),
                         source: e,
                     },
                     contents_buf,
@@ -293,12 +293,12 @@ impl ApiSpecFile {
             }
         };
 
-        match &spec_file_name {
+        match &doc_file_name {
             ApiDocFileName::Versioned(v) => {
                 if *v.version() != parsed_version {
                     return Err((
-                        ApiSpecFileParseError::VersionMismatch {
-                            path: spec_file_name.path(),
+                        ApiDocFileParseError::VersionMismatch {
+                            path: doc_file_name.path(),
                             file_version: parsed_version,
                         },
                         contents_buf,
@@ -311,8 +311,8 @@ impl ApiSpecFile {
                     let expected_hash = hash_contents(&contents_buf);
                     if expected_hash != v.hash() {
                         return Err((
-                            ApiSpecFileParseError::HashMismatch {
-                                path: spec_file_name.path(),
+                            ApiDocFileParseError::HashMismatch {
+                                path: doc_file_name.path(),
                                 expected: expected_hash,
                                 actual: v.hash().to_owned(),
                             },
@@ -324,8 +324,8 @@ impl ApiSpecFile {
             ApiDocFileName::Lockstep(_) => {}
         }
 
-        Ok(ApiSpecFile {
-            name: spec_file_name,
+        Ok(ApiDocFile {
+            name: doc_file_name,
             value: DebugIgnore(value),
             contents: DebugIgnore(openapi),
             contents_buf: DebugIgnore(contents_buf),
@@ -334,7 +334,7 @@ impl ApiSpecFile {
     }
 
     /// Returns the name of the OpenAPI document
-    pub fn spec_file_name(&self) -> &ApiDocFileName {
+    pub fn doc_file_name(&self) -> &ApiDocFileName {
         &self.name
     }
 
@@ -367,21 +367,21 @@ impl ApiSpecFile {
 /// **Be sure to check for load errors and warnings before using this
 /// structure.**
 ///
-/// The source `T` is generally a Newtype wrapper around `ApiSpecFile`.  `T`
+/// The source `T` is generally a Newtype wrapper around `ApiDocFile`.  `T`
 /// must impl `ApiLoad` (which applies constraints on loading these documents)
-/// and `AsRawFiles` (which converts the Newtype back to `ApiSpecFile` for
+/// and `AsRawFiles` (which converts the Newtype back to `ApiDocFile` for
 /// consumers that don't care which Newtype they're dealing with).  There are
 /// three values of `T` that get used here:
 ///
-/// * `BlessedApiSpecFile`: only one allowed per version, and it's okay if we
+/// * `BlessedApiDocFile`: only one allowed per version, and it's okay if we
 ///   find (and ignore) a file that doesn't match the API's configured type
 ///   (e.g., a lockstep file for a versioned API or vice versa).  This is
 ///   important for supporting changing the type of an API (e.g., converting
 ///   from lockstep to versioned).
-/// * `GeneratedApiSpecFile`: only one allowed per version.  It is an error to
+/// * `GeneratedApiDocFile`: only one allowed per version.  It is an error to
 ///   find files of a different type than the API (e.g., a lockstep file for a
 ///   versioned API or vice versa).
-/// * `Vec<LocalApiSpecFile>`: as the type suggests, more than one is allowed
+/// * `Vec<LocalApiDocFile>`: as the type suggests, more than one is allowed
 ///   per version.  It is an error to find files of a different type than the
 ///   API (e.g., a lockstep file for a versioned API or vice versa).
 ///
@@ -401,20 +401,20 @@ impl ApiSpecFile {
 ///   versioned API or vice versa depends on the source `T` (see above).  If
 ///   it's not an error when this happens, the file is still ignored.  Hence,
 ///   any files present in this structure _do_ match the expected type.
-pub struct ApiSpecFilesBuilder<'a, T> {
+pub struct ApiDocFilesBuilder<'a, T> {
     apis: &'a ManagedApis,
-    spec_files: BTreeMap<ApiIdent, ApiFiles<T>>,
+    doc_files: BTreeMap<ApiIdent, ApiFiles<T>>,
     error_accumulator: &'a mut ErrorAccumulator,
 }
 
-impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
+impl<'a, T: ApiLoad + AsRawFiles> ApiDocFilesBuilder<'a, T> {
     pub fn new(
         apis: &'a ManagedApis,
         error_accumulator: &'a mut ErrorAccumulator,
-    ) -> ApiSpecFilesBuilder<'a, T> {
-        ApiSpecFilesBuilder {
+    ) -> ApiDocFilesBuilder<'a, T> {
+        ApiDocFilesBuilder {
             apis,
-            spec_files: BTreeMap::new(),
+            doc_files: BTreeMap::new(),
             error_accumulator,
         }
     }
@@ -635,14 +635,14 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     }
 
     /// Load an already-parsed API document.
-    pub fn load_parsed(&mut self, file: ApiSpecFile) {
-        let ident = file.spec_file_name().ident();
+    pub fn load_parsed(&mut self, file: ApiDocFile) {
+        let ident = file.doc_file_name().ident();
         let api_version = file.version();
         let entry = self
-            .spec_files
+            .doc_files
             .entry(ident.clone())
             .or_insert_with(ApiFiles::new)
-            .spec_files
+            .doc_files
             .entry(api_version.clone());
 
         match entry {
@@ -667,7 +667,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
     pub fn load_maybe_unparseable(
         &mut self,
         file_name: ApiDocFileName,
-        result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
+        result: Result<ApiDocFile, (anyhow::Error, Vec<u8>)>,
     ) {
         match result {
             Ok(file) => {
@@ -719,10 +719,10 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
                 if let Some(version) = file_name.version() {
                     let ident = file_name.ident().clone();
                     let entry = self
-                        .spec_files
+                        .doc_files
                         .entry(ident)
                         .or_insert_with(ApiFiles::new)
-                        .spec_files
+                        .doc_files
                         .entry(version.clone());
 
                     match entry {
@@ -756,7 +756,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         ident: ApiIdent,
         unparseable: UnparseableFile,
     ) {
-        self.spec_files
+        self.doc_files
             .entry(ident)
             .or_insert_with(ApiFiles::new)
             .unparseable_files
@@ -798,7 +798,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         }
 
         let api_files =
-            self.spec_files.entry(ident.clone()).or_insert_with(ApiFiles::new);
+            self.doc_files.entry(ident.clone()).or_insert_with(ApiFiles::new);
         if let Some(previous) = api_files.latest_link.replace(links_to) {
             // unwrap(): we just put this here.
             let new_link = api_files.latest_link.as_ref().unwrap().to_string();
@@ -823,8 +823,8 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         version: &semver::Version,
         commit: GitCommitHash,
     ) {
-        if let Some(api_files) = self.spec_files.get_mut(ident)
-            && let Some(item) = api_files.spec_files.get_mut(version)
+        if let Some(api_files) = self.doc_files.get_mut(ident)
+            && let Some(item) = api_files.doc_files.get_mut(version)
         {
             item.set_git_stub_commit(commit);
         }
@@ -846,18 +846,18 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
 
     /// Returns the underlying set of files loaded
     pub fn into_map(self) -> BTreeMap<ApiIdent, ApiFiles<T>> {
-        self.spec_files
+        self.doc_files
     }
 }
 
 /// Describes a set of OpenAPI documents and associated "latest" symlink for a
 /// given API.
 ///
-/// Parametrized by `T` because callers use newtypes around `ApiSpecFile` to
-/// avoid confusing them.  See the documentation on [`ApiSpecFilesBuilder`].
+/// Parametrized by `T` because callers use newtypes around `ApiDocFile` to
+/// avoid confusing them.  See the documentation on [`ApiDocFilesBuilder`].
 #[derive(Debug)]
 pub struct ApiFiles<T> {
-    spec_files: BTreeMap<semver::Version, T>,
+    doc_files: BTreeMap<semver::Version, T>,
     latest_link: Option<VersionedApiDocFileName>,
     /// Files that exist on disk but couldn't be parsed. These are tracked so
     /// that generate can delete them and create correct files in their place.
@@ -867,14 +867,14 @@ pub struct ApiFiles<T> {
 impl<T: AsRawFiles> ApiFiles<T> {
     fn new() -> ApiFiles<T> {
         ApiFiles {
-            spec_files: BTreeMap::new(),
+            doc_files: BTreeMap::new(),
             latest_link: None,
             unparseable_files: Vec::new(),
         }
     }
 
     pub fn versions(&self) -> &BTreeMap<semver::Version, T> {
-        &self.spec_files
+        &self.doc_files
     }
 
     pub fn latest_link(&self) -> Option<&VersionedApiDocFileName> {
@@ -891,20 +891,20 @@ impl<T: AsRawFiles> ApiFiles<T> {
 ///
 /// This allows iterating over both valid and unparseable files while still
 /// being able to access their names.
-pub trait SpecFileInfo {
+pub trait DocFileInfo {
     /// Returns the spec file name.
-    fn spec_file_name(&self) -> &ApiDocFileName;
+    fn doc_file_name(&self) -> &ApiDocFileName;
 
     /// Returns the version from the parsed file, if available.
     ///
     /// For unparseable files, this returns `None`. Use
-    /// `spec_file_name().version()` to get the version from the filename
+    /// `doc_file_name().version()` to get the version from the filename
     /// instead.
     fn version(&self) -> Option<&semver::Version>;
 }
 
-impl SpecFileInfo for ApiSpecFile {
-    fn spec_file_name(&self) -> &ApiDocFileName {
+impl DocFileInfo for ApiDocFile {
+    fn doc_file_name(&self) -> &ApiDocFileName {
         &self.name
     }
 
@@ -913,30 +913,30 @@ impl SpecFileInfo for ApiSpecFile {
     }
 }
 
-/// Implemented by Newtype wrappers around `ApiSpecFile` to convert back to an
-/// iterator of `&'a dyn SpecFileInfo` for callers that do not care which
+/// Implemented by Newtype wrappers around `ApiDocFile` to convert back to an
+/// iterator of `&'a dyn DocFileInfo` for callers that do not care which
 /// Newtype they're operating on.
 ///
 /// This is sort of like `Deref` except that some of the implementors are
-/// collections.  See [`ApiSpecFilesBuilder`] for more on this.
+/// collections.  See [`ApiDocFilesBuilder`] for more on this.
 pub trait AsRawFiles: Debug {
     fn as_raw_files<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = &'a dyn SpecFileInfo> + 'a>;
+    ) -> Box<dyn Iterator<Item = &'a dyn DocFileInfo> + 'a>;
 }
 
-impl AsRawFiles for Vec<ApiSpecFile> {
+impl AsRawFiles for Vec<ApiDocFile> {
     fn as_raw_files<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = &'a dyn SpecFileInfo> + 'a> {
-        Box::new(self.iter().map(|f| f as &dyn SpecFileInfo))
+    ) -> Box<dyn Iterator<Item = &'a dyn DocFileInfo> + 'a> {
+        Box::new(self.iter().map(|f| f as &dyn DocFileInfo))
     }
 }
 
-/// Implemented by Newtype wrappers around `ApiSpecFile` to load the newtype
-/// from an `ApiSpecFile`.
+/// Implemented by Newtype wrappers around `ApiDocFile` to load the newtype
+/// from an `ApiDocFile`.
 ///
-/// This is a bit like `TryFrom<Vec<ApiSpecFile>>` but we cannot use that
+/// This is a bit like `TryFrom<Vec<ApiDocFile>>` but we cannot use that
 /// directly because of the orphan rules (neither `TryFrom` nor `Vec` is defined
 /// in this package).
 pub trait ApiLoad {
@@ -962,14 +962,14 @@ pub trait ApiLoad {
     type Unparseable;
 
     /// Record having loaded a single OpenAPI document for an API.
-    fn make_item(raw: ApiSpecFile) -> Self;
+    fn make_item(raw: ApiDocFile) -> Self;
 
     /// Try to record additional OpenAPI documents for an API.
     ///
     /// (This trait API might seem a little strange.  It looks this way because
     /// every implementor supports loading a single OpenAPI document, but only
     /// some allow more than one.)
-    fn try_extend(&mut self, raw: ApiSpecFile) -> anyhow::Result<()>;
+    fn try_extend(&mut self, raw: ApiDocFile) -> anyhow::Result<()>;
 
     /// Try to create unparseable file data.
     ///
@@ -994,7 +994,7 @@ pub trait ApiLoad {
     /// Set the Git stub commit hash on the most recently loaded item.
     ///
     /// The default implementation does nothing. Only
-    /// `Vec<LocalApiSpecFile>` overrides this.
+    /// `Vec<LocalApiDocFile>` overrides this.
     fn set_git_stub_commit(&mut self, _commit: GitCommitHash) {}
 }
 

--- a/crates/dropshot-api-manager/src/doc_files_local.rs
+++ b/crates/dropshot-api-manager/src/doc_files_local.rs
@@ -5,12 +5,12 @@
 
 use crate::{
     apis::ManagedApis,
-    environment::ErrorAccumulator,
-    spec_files_generic::{
-        ApiFiles, ApiLoad, ApiSpecFile, ApiSpecFilesBuilder, AsRawFiles,
-        SpecFileInfo, parse_lockstep_file_name, parse_versioned_file_name,
+    doc_files_generic::{
+        ApiDocFile, ApiDocFilesBuilder, ApiFiles, ApiLoad, AsRawFiles,
+        DocFileInfo, parse_lockstep_file_name, parse_versioned_file_name,
         parse_versioned_git_stub_file_name,
     },
+    environment::ErrorAccumulator,
     vcs::RepoVcs,
 };
 use anyhow::{Context, anyhow};
@@ -45,11 +45,11 @@ pub struct LocalApiUnparseable {
 /// to merge conflict markers). Unparseable files are tracked so they can be
 /// regenerated during the generate command.
 #[derive(Debug)]
-pub enum LocalApiSpecFile {
+pub enum LocalApiDocFile {
     /// A valid, successfully parsed OpenAPI document.
     Valid {
         /// The parsed OpenAPI document.
-        spec: Box<ApiSpecFile>,
+        doc: Box<ApiDocFile>,
         /// Commit hash parsed from the `.gitstub` file, if this file was
         /// loaded from one. `None` for regular JSON files.
         git_stub_commit: Option<GitCommitHash>,
@@ -58,11 +58,11 @@ pub enum LocalApiSpecFile {
     Unparseable(LocalApiUnparseable),
 }
 
-impl LocalApiSpecFile {
+impl LocalApiDocFile {
     /// Returns the spec file name.
-    pub fn spec_file_name(&self) -> &ApiDocFileName {
+    pub fn doc_file_name(&self) -> &ApiDocFileName {
         match self {
-            Self::Valid { spec, .. } => spec.spec_file_name(),
+            Self::Valid { doc, .. } => doc.doc_file_name(),
             Self::Unparseable(u) => &u.name,
         }
     }
@@ -72,7 +72,7 @@ impl LocalApiSpecFile {
     /// This works for both valid and unparseable files.
     pub fn contents(&self) -> &[u8] {
         match self {
-            Self::Valid { spec, .. } => spec.contents(),
+            Self::Valid { doc, .. } => doc.contents(),
             Self::Unparseable(u) => &u.contents,
         }
     }
@@ -92,39 +92,39 @@ impl LocalApiSpecFile {
     }
 }
 
-impl SpecFileInfo for LocalApiSpecFile {
-    fn spec_file_name(&self) -> &ApiDocFileName {
-        self.spec_file_name()
+impl DocFileInfo for LocalApiDocFile {
+    fn doc_file_name(&self) -> &ApiDocFileName {
+        self.doc_file_name()
     }
 
     fn version(&self) -> Option<&semver::Version> {
         match self {
-            Self::Valid { spec, .. } => Some(spec.version()),
+            Self::Valid { doc, .. } => Some(doc.version()),
             Self::Unparseable(_) => None,
         }
     }
 }
 
-// Trait impls that allow us to use `ApiFiles<Vec<LocalApiSpecFile>>`
+// Trait impls that allow us to use `ApiFiles<Vec<LocalApiDocFile>>`
 //
 // Note that this is a `Vec` because it's allowed to have more than one
-// LocalApiSpecFile for a given version.
+// LocalApiDocFile for a given version.
 
-impl ApiLoad for Vec<LocalApiSpecFile> {
+impl ApiLoad for Vec<LocalApiDocFile> {
     const MISCONFIGURATIONS_ALLOWED: bool = false;
     type Unparseable = LocalApiUnparseable;
 
-    fn try_extend(&mut self, item: ApiSpecFile) -> anyhow::Result<()> {
-        self.push(LocalApiSpecFile::Valid {
-            spec: Box::new(item),
+    fn try_extend(&mut self, item: ApiDocFile) -> anyhow::Result<()> {
+        self.push(LocalApiDocFile::Valid {
+            doc: Box::new(item),
             git_stub_commit: None,
         });
         Ok(())
     }
 
-    fn make_item(raw: ApiSpecFile) -> Self {
-        vec![LocalApiSpecFile::Valid {
-            spec: Box::new(raw),
+    fn make_item(raw: ApiDocFile) -> Self {
+        vec![LocalApiDocFile::Valid {
+            doc: Box::new(raw),
             git_stub_commit: None,
         }]
     }
@@ -137,15 +137,15 @@ impl ApiLoad for Vec<LocalApiSpecFile> {
     }
 
     fn unparseable_into_self(unparseable: Self::Unparseable) -> Self {
-        vec![LocalApiSpecFile::Unparseable(unparseable)]
+        vec![LocalApiDocFile::Unparseable(unparseable)]
     }
 
     fn extend_unparseable(&mut self, unparseable: Self::Unparseable) {
-        self.push(LocalApiSpecFile::Unparseable(unparseable));
+        self.push(LocalApiDocFile::Unparseable(unparseable));
     }
 
     fn set_git_stub_commit(&mut self, commit: GitCommitHash) {
-        if let Some(LocalApiSpecFile::Valid { git_stub_commit, .. }) =
+        if let Some(LocalApiDocFile::Valid { git_stub_commit, .. }) =
             self.last_mut()
         {
             *git_stub_commit = Some(commit);
@@ -153,11 +153,11 @@ impl ApiLoad for Vec<LocalApiSpecFile> {
     }
 }
 
-impl AsRawFiles for Vec<LocalApiSpecFile> {
+impl AsRawFiles for Vec<LocalApiDocFile> {
     fn as_raw_files<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = &'a dyn SpecFileInfo> + 'a> {
-        Box::new(self.iter().map(|f| f as &dyn SpecFileInfo))
+    ) -> Box<dyn Iterator<Item = &'a dyn DocFileInfo> + 'a> {
+        Box::new(self.iter().map(|f| f as &dyn DocFileInfo))
     }
 }
 
@@ -167,15 +167,15 @@ impl AsRawFiles for Vec<LocalApiSpecFile> {
 /// structure.**
 ///
 /// For more on what's been validated at this point, see
-/// [`ApiSpecFilesBuilder`].
+/// [`ApiDocFilesBuilder`].
 #[derive(Debug, Default)]
 pub struct LocalFiles {
     /// The loaded local files.
-    files: BTreeMap<ApiIdent, ApiFiles<Vec<LocalApiSpecFile>>>,
+    files: BTreeMap<ApiIdent, ApiFiles<Vec<LocalApiDocFile>>>,
 }
 
 impl Deref for LocalFiles {
-    type Target = BTreeMap<ApiIdent, ApiFiles<Vec<LocalApiSpecFile>>>;
+    type Target = BTreeMap<ApiIdent, ApiFiles<Vec<LocalApiDocFile>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.files
@@ -205,8 +205,8 @@ impl LocalFiles {
     }
 }
 
-impl From<ApiSpecFilesBuilder<'_, Vec<LocalApiSpecFile>>> for LocalFiles {
-    fn from(api_files: ApiSpecFilesBuilder<Vec<LocalApiSpecFile>>) -> Self {
+impl From<ApiDocFilesBuilder<'_, Vec<LocalApiDocFile>>> for LocalFiles {
+    fn from(api_files: ApiDocFilesBuilder<Vec<LocalApiDocFile>>) -> Self {
         LocalFiles { files: api_files.into_map() }
     }
 }
@@ -239,15 +239,15 @@ enum LocalFileResult {
     // --- Successfully parsed filename + deserialized ---
     LockstepDeserialized {
         file_name: ApiDocFileName,
-        result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
+        result: Result<ApiDocFile, (anyhow::Error, Vec<u8>)>,
     },
     VersionedDeserialized {
         file_name: ApiDocFileName,
-        result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
+        result: Result<ApiDocFile, (anyhow::Error, Vec<u8>)>,
     },
     GitStubDeserialized {
         file_name: ApiDocFileName,
-        result: Result<ApiSpecFile, (anyhow::Error, Vec<u8>)>,
+        result: Result<ApiDocFile, (anyhow::Error, Vec<u8>)>,
         commit: GitCommitHash,
     },
 
@@ -451,7 +451,7 @@ fn process_local_entry(
             // Try to parse as a lockstep filename. If that fails, defer
             // diagnostics to the reduce phase (the builder methods produce
             // the correct warnings/errors depending on T).
-            let Some(spec_file_name) =
+            let Some(doc_file_name) =
                 parse_lockstep_file_name(apis, &file_name)
                     .ok()
                     .map(ApiDocFileName::from)
@@ -467,9 +467,9 @@ fn process_local_entry(
             };
 
             let result =
-                ApiSpecFile::for_contents(spec_file_name.clone(), contents);
+                ApiDocFile::for_contents(doc_file_name.clone(), contents);
             LocalFileResult::LockstepDeserialized {
-                file_name: spec_file_name,
+                file_name: doc_file_name,
                 result,
             }
         }
@@ -479,7 +479,7 @@ fn process_local_entry(
             file_name,
             path,
         } => {
-            let Some(spec_file_name) =
+            let Some(doc_file_name) =
                 parse_versioned_file_name(apis, &dir_basename, &file_name)
                     .ok()
                     .map(ApiDocFileName::from)
@@ -498,15 +498,15 @@ fn process_local_entry(
             };
 
             let result =
-                ApiSpecFile::for_contents(spec_file_name.clone(), contents);
+                ApiDocFile::for_contents(doc_file_name.clone(), contents);
             LocalFileResult::VersionedDeserialized {
-                file_name: spec_file_name,
+                file_name: doc_file_name,
                 result,
             }
         }
 
         LocalDiscoveredEntry::GitStub { dir_basename, file_name, path } => {
-            let Some(spec_file_name) = parse_versioned_git_stub_file_name(
+            let Some(doc_file_name) = parse_versioned_git_stub_file_name(
                 apis,
                 &dir_basename,
                 &file_name,
@@ -533,7 +533,7 @@ fn process_local_entry(
                 Ok(g) => g,
                 Err(error) => {
                     return LocalFileResult::GitStubUnresolvable {
-                        file_name: spec_file_name,
+                        file_name: doc_file_name,
                         original_contents: git_stub_contents.into_bytes(),
                         reason: anyhow!(error).context(format!(
                             "Git stub {:?} could not be parsed",
@@ -546,7 +546,7 @@ fn process_local_entry(
             // Check if the stub needs rewriting to canonical format.
             if git_stub.needs_rewrite() {
                 return LocalFileResult::GitStubUnresolvable {
-                    file_name: spec_file_name,
+                    file_name: doc_file_name,
                     original_contents: git_stub_contents.into_bytes(),
                     reason: anyhow!(
                         "Git stub {:?} needs to be rewritten to \
@@ -563,7 +563,7 @@ fn process_local_entry(
                 Ok(c) => c,
                 Err(error) => {
                     return LocalFileResult::GitStubUnresolvable {
-                        file_name: spec_file_name,
+                        file_name: doc_file_name,
                         original_contents: git_stub_contents.into_bytes(),
                         reason: error.context(format!(
                             "Git stub {:?} could not be resolved",
@@ -576,9 +576,9 @@ fn process_local_entry(
             // Deserialize the resolved contents.
             let commit = git_stub.commit();
             let result =
-                ApiSpecFile::for_contents(spec_file_name.clone(), contents);
+                ApiDocFile::for_contents(doc_file_name.clone(), contents);
             LocalFileResult::GitStubDeserialized {
-                file_name: spec_file_name,
+                file_name: doc_file_name,
                 result,
                 commit,
             }
@@ -632,7 +632,7 @@ pub fn walk_local_directory<'a, T: ApiLoad + AsRawFiles>(
     error_accumulator: &'a mut ErrorAccumulator,
     repo_root: &Utf8Path,
     vcs: &RepoVcs,
-) -> anyhow::Result<ApiSpecFilesBuilder<'a, T>> {
+) -> anyhow::Result<ApiDocFilesBuilder<'a, T>> {
     // Phase 1: discover entries (sequential, fast).
     let entries = discover_local_entries(dir)?;
 
@@ -643,7 +643,7 @@ pub fn walk_local_directory<'a, T: ApiLoad + AsRawFiles>(
         .collect();
 
     // Phase 3: reduce into builder (sequential).
-    let mut api_files = ApiSpecFilesBuilder::new(apis, error_accumulator);
+    let mut api_files = ApiDocFilesBuilder::new(apis, error_accumulator);
 
     // Cache for `versioned_directory()` results to avoid duplicate
     // warnings for entries from the same directory.

--- a/crates/dropshot-api-manager/src/environment.rs
+++ b/crates/dropshot-api-manager/src/environment.rs
@@ -5,14 +5,14 @@
 
 use crate::{
     apis::ManagedApis,
+    doc_files_blessed::{BlessedApiDocFile, BlessedFiles},
+    doc_files_generated::GeneratedFiles,
+    doc_files_generic::ApiDocFilesBuilder,
+    doc_files_local::{LocalFiles, walk_local_directory},
     output::{
         Styles,
         headers::{GENERATING, HEADER_WIDTH},
     },
-    spec_files_blessed::{BlessedApiSpecFile, BlessedFiles},
-    spec_files_generated::GeneratedFiles,
-    spec_files_generic::ApiSpecFilesBuilder,
-    spec_files_local::{LocalFiles, walk_local_directory},
     vcs::{RepoVcs, RepoVcsKind, VcsRevision},
 };
 use anyhow::Context;
@@ -305,7 +305,7 @@ impl BlessedSource {
                     "Loading".style(styles.success_header),
                     local_directory,
                 )?;
-                let api_files: ApiSpecFilesBuilder<'_, BlessedApiSpecFile> =
+                let api_files: ApiDocFilesBuilder<'_, BlessedApiDocFile> =
                     walk_local_directory(
                         local_directory,
                         apis,

--- a/crates/dropshot-api-manager/src/lib.rs
+++ b/crates/dropshot-api-manager/src/lib.rs
@@ -11,14 +11,14 @@
 mod apis;
 mod cmd;
 mod compatibility;
+mod doc_files_blessed;
+mod doc_files_generated;
+mod doc_files_generic;
+mod doc_files_local;
 mod environment;
 mod iter_only;
 mod output;
 mod resolved;
-mod spec_files_blessed;
-mod spec_files_generated;
-mod spec_files_generic;
-mod spec_files_local;
 pub mod test_util;
 mod validation;
 mod vcs;

--- a/crates/dropshot-api-manager/src/output.rs
+++ b/crates/dropshot-api-manager/src/output.rs
@@ -159,7 +159,7 @@ fn format_diff_path(prefix: &str, path: &Utf8Path) -> String {
     }
 }
 
-pub(crate) fn display_api_spec(api: &ManagedApi, styles: &Styles) -> String {
+pub(crate) fn display_api_doc(api: &ManagedApi, styles: &Styles) -> String {
     let mut versions = api.iter_versions_semver();
     let count = versions.len();
     let latest_version =
@@ -182,7 +182,7 @@ pub(crate) fn display_api_spec(api: &ManagedApi, styles: &Styles) -> String {
     }
 }
 
-pub(crate) fn display_api_spec_version(
+pub(crate) fn display_api_doc_version(
     api: &ManagedApi,
     version: &semver::Version,
     styles: &Styles,
@@ -499,7 +499,7 @@ fn summarize_one(
             writer,
             "{:>HEADER_WIDTH$} {}",
             FRESH.style(styles.success_header),
-            display_api_spec_version(api, version, styles, resolution),
+            display_api_doc_version(api, version, styles, resolution),
         )?;
     } else {
         // There were one or more problems, some of which may be unfixable.
@@ -512,7 +512,7 @@ fn summarize_one(
                 assert!(resolution.has_problems());
                 STALE.style(styles.warning_header)
             },
-            display_api_spec_version(api, version, styles, resolution),
+            display_api_doc_version(api, version, styles, resolution),
         )?;
 
         let compat_ctx = CompatDisplayContext {
@@ -584,9 +584,9 @@ where
             let diff =
                 TextDiff::from_lines(blessed.contents(), generated.contents());
             let path1 =
-                env.openapi_abs_dir().join(blessed.spec_file_name().path());
+                env.openapi_abs_dir().join(blessed.doc_file_name().path());
             let path2 =
-                env.openapi_abs_dir().join(generated.spec_file_name().path());
+                env.openapi_abs_dir().join(generated.doc_file_name().path());
             let indent = " ".repeat(HEADER_WIDTH + 1);
             write_diff(
                 &diff,
@@ -614,10 +614,10 @@ where
                     generated.contents(),
                 );
                 let path1 =
-                    env.openapi_abs_dir().join(found.spec_file_name().path());
+                    env.openapi_abs_dir().join(found.doc_file_name().path());
                 let path2 = env
                     .openapi_abs_dir()
-                    .join(generated.spec_file_name().path());
+                    .join(generated.doc_file_name().path());
                 Some((diff, path1, path2))
             }
             VersionProblem::ExtraFileStale {
@@ -628,19 +628,19 @@ where
                 let diff = TextDiff::from_lines(actual, expected);
                 Some((diff, full_path.clone(), full_path.clone()))
             }
-            VersionProblem::LocalVersionStale { spec_files, generated }
-                if spec_files.len() == 1 =>
+            VersionProblem::LocalVersionStale { doc_files, generated }
+                if doc_files.len() == 1 =>
             {
                 let diff = TextDiff::from_lines(
-                    spec_files[0].contents(),
+                    doc_files[0].contents(),
                     generated.contents(),
                 );
                 let path1 = env
                     .openapi_abs_dir()
-                    .join(spec_files[0].spec_file_name().path());
+                    .join(doc_files[0].doc_file_name().path());
                 let path2 = env
                     .openapi_abs_dir()
-                    .join(generated.spec_file_name().path());
+                    .join(generated.doc_file_name().path());
                 Some((diff, path1, path2))
             }
             _ => None,

--- a/crates/dropshot-api-manager/src/resolved.rs
+++ b/crates/dropshot-api-manager/src/resolved.rs
@@ -8,13 +8,13 @@ use crate::{
         ApiCompatIssue, CompatDedupMap, CompatIssueLocation,
         FinalizedCompatDedupMap, api_compatible,
     },
+    doc_files_blessed::{BlessedApiDocFile, BlessedFiles, BlessedGitStub},
+    doc_files_generated::{GeneratedApiDocFile, GeneratedFiles},
+    doc_files_generic::{ApiFiles, UnparseableFile},
+    doc_files_local::{LocalApiDocFile, LocalFiles},
     environment::ResolvedEnv,
     iter_only::iter_only,
     output::{InlineErrorChain, plural},
-    spec_files_blessed::{BlessedApiSpecFile, BlessedFiles, BlessedGitStub},
-    spec_files_generated::{GeneratedApiSpecFile, GeneratedFiles},
-    spec_files_generic::{ApiFiles, UnparseableFile},
-    spec_files_local::{LocalApiSpecFile, LocalFiles},
     validation::{
         CheckStale, CheckStatus, DynValidationFn, overwrite_file, validate,
     },
@@ -149,10 +149,10 @@ impl Display for ResolutionKind {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[expect(missing_docs)]
 pub enum ProblemKind {
-    LocalSpecFileOrphaned,
+    LocalDocFileOrphaned,
     UnparseableLocalFile,
     BlessedVersionMissingLocal,
-    BlessedVersionExtraLocalSpec,
+    BlessedVersionExtraLocalDoc,
     BlessedVersionCompareError,
     BlessedVersionBroken,
     BlessedLatestVersionBytewiseMismatch,
@@ -225,13 +225,13 @@ impl ProblemSummary {
 pub enum NonVersionProblem<'a> {
     #[error(
         "A local OpenAPI document was found that does not correspond to a \
-         supported version of this API: {spec_file_name}.  This is unusual, \
+         supported version of this API: {doc_file_name}.  This is unusual, \
          but it could happen if you're either retiring an older version of \
          this API or if you created this version in this branch and later \
          merged with upstream and had to change your local version number.  \
          In either case, this tool can remove the unused file for you."
     )]
-    LocalSpecFileOrphaned { spec_file_name: VersionedApiDocFileName },
+    LocalDocFileOrphaned { doc_file_name: VersionedApiDocFileName },
 
     #[error(
         "A local OpenAPI document could not be parsed: {}. \
@@ -269,23 +269,23 @@ pub enum VersionProblem<'a> {
          missing a local OpenAPI document. This can happen with dependent \
          commits or PRs. This tool can restore the file from the blessed \
          version for you: {}",
-        blessed.versioned_spec_file_name()
+        blessed.versioned_doc_file_name()
     )]
     BlessedVersionMissingLocal {
-        blessed: &'a BlessedApiSpecFile,
+        blessed: &'a BlessedApiDocFile,
         git_stub: Option<GitStub>,
     },
 
     #[error(
         "For this blessed version, found an extra OpenAPI document that does \
-         not match the blessed (upstream) OpenAPI document: {spec_file_name}.  \
+         not match the blessed (upstream) OpenAPI document: {doc_file_name}.  \
          This can happen if you created this version of the API in this branch, \
          then merged with an upstream commit that also added the same version \
          number.  In that case, you likely already bumped your local version \
          number (when you merged the list of supported versions in Rust) and \
          this file is vestigial. This tool can remove the unused file for you."
     )]
-    BlessedVersionExtraLocalSpec { spec_file_name: VersionedApiDocFileName },
+    BlessedVersionExtraLocalDoc { doc_file_name: VersionedApiDocFileName },
 
     #[error(
         "error comparing OpenAPI document generated from current code with \
@@ -310,8 +310,8 @@ pub enum VersionProblem<'a> {
          changes to any endpoints."
     )]
     BlessedLatestVersionBytewiseMismatch {
-        blessed: &'a BlessedApiSpecFile,
-        generated: &'a GeneratedApiSpecFile,
+        blessed: &'a BlessedApiDocFile,
+        generated: &'a GeneratedApiDocFile,
     },
 
     #[error(
@@ -319,16 +319,16 @@ pub enum VersionProblem<'a> {
          only expected if you're adding a new lockstep API.  This tool can \
          generate the file for you."
     )]
-    LockstepMissingLocal { generated: &'a GeneratedApiSpecFile },
+    LockstepMissingLocal { generated: &'a GeneratedApiDocFile },
 
     #[error(
         "For this lockstep API, OpenAPI document generated from the current \
          code does not match the local file: {:?}.  This tool can update the \
-         local file for you.", generated.spec_file_name().path()
+         local file for you.", generated.doc_file_name().path()
     )]
     LockstepStale {
-        found: &'a LocalApiSpecFile,
-        generated: &'a GeneratedApiSpecFile,
+        found: &'a LocalApiDocFile,
+        generated: &'a GeneratedApiDocFile,
     },
 
     #[error(
@@ -336,14 +336,14 @@ pub enum VersionProblem<'a> {
          This is normal if you have added or changed this API version.  \
          This tool can generate the file for you."
     )]
-    LocalVersionMissingLocal { generated: &'a GeneratedApiSpecFile },
+    LocalVersionMissingLocal { generated: &'a GeneratedApiDocFile },
 
     #[error(
         "Extra (incorrect) OpenAPI documents were found for locally-added \
-         version: {spec_file_names}.  This tool can remove the files for you."
+         version: {doc_file_names}.  This tool can remove the files for you."
     )]
     LocalVersionExtra {
-        spec_file_names: DisplayableVec<VersionedApiDocFileName>,
+        doc_file_names: DisplayableVec<VersionedApiDocFileName>,
     },
 
     #[error(
@@ -351,7 +351,7 @@ pub enum VersionProblem<'a> {
          from the current code does not match the local file: {}. \
          This tool can update the local file(s) for you.",
         DisplayableVec(
-            spec_files.iter().map(|s| s.spec_file_name().to_string()).collect()
+            doc_files.iter().map(|s| s.doc_file_name().to_string()).collect()
         )
     )]
     // For versioned APIs, since the filename has its own hash in it, when the
@@ -360,8 +360,8 @@ pub enum VersionProblem<'a> {
     // one will be missing.  The fix will be to remove all the incorrect ones
     // and add the correct one.
     LocalVersionStale {
-        spec_files: Vec<&'a LocalApiSpecFile>,
-        generated: &'a GeneratedApiSpecFile,
+        doc_files: Vec<&'a LocalApiDocFile>,
+        generated: &'a GeneratedApiDocFile,
     },
 
     #[error(
@@ -398,7 +398,7 @@ pub enum VersionProblem<'a> {
          you."
     )]
     BlessedVersionShouldBeGitStub {
-        local_file: &'a LocalApiSpecFile,
+        local_file: &'a LocalApiDocFile,
         git_stub: GitStub,
     },
 
@@ -407,8 +407,8 @@ pub enum VersionProblem<'a> {
          JSON. This tool can perform the conversion for you."
     )]
     GitStubShouldBeJson {
-        local_file: &'a LocalApiSpecFile,
-        blessed: &'a BlessedApiSpecFile,
+        local_file: &'a LocalApiDocFile,
+        blessed: &'a BlessedApiDocFile,
     },
 
     #[error(
@@ -417,8 +417,8 @@ pub enum VersionProblem<'a> {
          blessed version for you."
     )]
     BlessedVersionCorruptedLocal {
-        local_file: &'a LocalApiSpecFile,
-        blessed: &'a BlessedApiSpecFile,
+        local_file: &'a LocalApiDocFile,
+        blessed: &'a BlessedApiDocFile,
         /// If Some, regenerate as a Git stub instead of JSON.
         git_stub: Option<GitStub>,
     },
@@ -427,14 +427,14 @@ pub enum VersionProblem<'a> {
         "Duplicate local file found: both JSON and Git stub versions exist for \
          this API version. This tool can remove the redundant file for you."
     )]
-    DuplicateLocalFile { local_file: &'a LocalApiSpecFile },
+    DuplicateLocalFile { local_file: &'a LocalApiDocFile },
 
     #[error(
         "Git stub has an outdated commit reference that is no longer \
          an ancestor of the merge base. This can happen after a rebase or \
          force-push. This tool can update the Git stub for you."
     )]
-    GitStubCommitStale { local_file: &'a LocalApiSpecFile, git_stub: GitStub },
+    GitStubCommitStale { local_file: &'a LocalApiDocFile, git_stub: GitStub },
 
     #[error(
         "The first commit for this blessed version could not be determined. This \
@@ -444,7 +444,7 @@ pub enum VersionProblem<'a> {
          // <source>".
     )]
     GitStubFirstCommitUnknown {
-        spec_file_name: VersionedApiDocFileName,
+        doc_file_name: VersionedApiDocFileName,
         #[source]
         source: anyhow::Error,
     },
@@ -457,8 +457,8 @@ impl<'a> NonVersionProblem<'a> {
     /// variant without updating this method causes a compile error.
     pub fn kind(&self) -> ProblemKind {
         match self {
-            NonVersionProblem::LocalSpecFileOrphaned { .. } => {
-                ProblemKind::LocalSpecFileOrphaned
+            NonVersionProblem::LocalDocFileOrphaned { .. } => {
+                ProblemKind::LocalDocFileOrphaned
             }
             NonVersionProblem::UnparseableLocalFile { .. } => {
                 ProblemKind::UnparseableLocalFile
@@ -478,9 +478,9 @@ impl<'a> NonVersionProblem<'a> {
 
     pub fn fix(&'a self) -> Option<Fix<'a>> {
         match self {
-            NonVersionProblem::LocalSpecFileOrphaned { spec_file_name } => {
+            NonVersionProblem::LocalDocFileOrphaned { doc_file_name } => {
                 Some(Fix::DeleteFiles {
-                    files: DisplayableVec(vec![spec_file_name.clone().into()]),
+                    files: DisplayableVec(vec![doc_file_name.clone().into()]),
                 })
             }
             NonVersionProblem::UnparseableLocalFile { unparseable_file } => {
@@ -507,8 +507,8 @@ impl<'a> VersionProblem<'a> {
             VersionProblem::BlessedVersionMissingLocal { .. } => {
                 ProblemKind::BlessedVersionMissingLocal
             }
-            VersionProblem::BlessedVersionExtraLocalSpec { .. } => {
-                ProblemKind::BlessedVersionExtraLocalSpec
+            VersionProblem::BlessedVersionExtraLocalDoc { .. } => {
+                ProblemKind::BlessedVersionExtraLocalDoc
             }
             VersionProblem::BlessedVersionCompareError { .. } => {
                 ProblemKind::BlessedVersionCompareError
@@ -573,7 +573,7 @@ impl<'a> VersionProblem<'a> {
                 compatibility_issues
             }
             VersionProblem::BlessedVersionMissingLocal { .. }
-            | VersionProblem::BlessedVersionExtraLocalSpec { .. }
+            | VersionProblem::BlessedVersionExtraLocalDoc { .. }
             | VersionProblem::BlessedVersionCompareError { .. }
             | VersionProblem::BlessedLatestVersionBytewiseMismatch { .. }
             | VersionProblem::LockstepMissingLocal { .. }
@@ -602,9 +602,9 @@ impl<'a> VersionProblem<'a> {
                 blessed,
                 git_stub: git_stub.as_ref(),
             }),
-            VersionProblem::BlessedVersionExtraLocalSpec { spec_file_name } => {
+            VersionProblem::BlessedVersionExtraLocalDoc { doc_file_name } => {
                 Some(Fix::DeleteFiles {
-                    files: DisplayableVec(vec![spec_file_name.clone().into()]),
+                    files: DisplayableVec(vec![doc_file_name.clone().into()]),
                 })
             }
             VersionProblem::BlessedVersionCompareError { .. } => None,
@@ -620,10 +620,10 @@ impl<'a> VersionProblem<'a> {
                     generated,
                 })
             }
-            VersionProblem::LocalVersionExtra { spec_file_names } => {
+            VersionProblem::LocalVersionExtra { doc_file_names } => {
                 Some(Fix::DeleteFiles {
                     files: DisplayableVec(
-                        spec_file_names
+                        doc_file_names
                             .0
                             .iter()
                             .cloned()
@@ -632,10 +632,10 @@ impl<'a> VersionProblem<'a> {
                     ),
                 })
             }
-            VersionProblem::LocalVersionStale { spec_files, generated } => {
+            VersionProblem::LocalVersionStale { doc_files, generated } => {
                 Some(Fix::UpdateVersionedFiles {
                     old: DisplayableVec(
-                        spec_files.iter().map(|s| s.spec_file_name()).collect(),
+                        doc_files.iter().map(|s| s.doc_file_name()).collect(),
                     ),
                     generated,
                 })
@@ -664,7 +664,7 @@ impl<'a> VersionProblem<'a> {
             VersionProblem::DuplicateLocalFile { local_file } => {
                 Some(Fix::DeleteFiles {
                     files: DisplayableVec(vec![
-                        local_file.spec_file_name().clone(),
+                        local_file.doc_file_name().clone(),
                     ]),
                 })
             }
@@ -681,11 +681,11 @@ pub enum Fix<'a> {
         files: DisplayableVec<ApiDocFileName>,
     },
     UpdateLockstepFile {
-        generated: &'a GeneratedApiSpecFile,
+        generated: &'a GeneratedApiDocFile,
     },
     UpdateVersionedFiles {
         old: DisplayableVec<&'a ApiDocFileName>,
-        generated: &'a GeneratedApiSpecFile,
+        generated: &'a GeneratedApiDocFile,
     },
     UpdateExtraFile {
         path: &'a Utf8Path,
@@ -697,18 +697,18 @@ pub enum Fix<'a> {
     },
     /// Convert a full JSON file to a Git stub.
     ConvertToGitStub {
-        local_file: &'a LocalApiSpecFile,
+        local_file: &'a LocalApiDocFile,
         git_stub: &'a GitStub,
     },
     /// Convert a Git stub back to a full JSON file.
     ConvertToJson {
-        local_file: &'a LocalApiSpecFile,
-        blessed: &'a BlessedApiSpecFile,
+        local_file: &'a LocalApiDocFile,
+        blessed: &'a BlessedApiDocFile,
     },
     /// Regenerate a corrupted local file from the blessed content.
     RegenerateFromBlessed {
-        local_file: &'a LocalApiSpecFile,
-        blessed: &'a BlessedApiSpecFile,
+        local_file: &'a LocalApiDocFile,
+        blessed: &'a BlessedApiDocFile,
         /// If Some, regenerate as a Git stub instead of JSON.
         git_stub: Option<&'a GitStub>,
     },
@@ -717,16 +717,16 @@ pub enum Fix<'a> {
     ///
     /// Unlike `RegenerateFromBlessed`, there is no existing `local_file` to
     /// delete. The target path is derived from
-    /// `blessed.versioned_spec_file_name()`.
+    /// `blessed.versioned_doc_file_name()`.
     RestoreFromBlessed {
-        blessed: &'a BlessedApiSpecFile,
+        blessed: &'a BlessedApiDocFile,
         /// If Some, write as a Git stub instead of JSON.
         git_stub: Option<&'a GitStub>,
     },
     /// Update a Git stub whose commit hash has become stale (e.g.,
     /// after a rebase).
     UpdateGitStub {
-        local_file: &'a LocalApiSpecFile,
+        local_file: &'a LocalApiDocFile,
         git_stub: &'a GitStub,
     },
     /// Delete an unparseable file (e.g., one with merge conflict markers).
@@ -749,7 +749,7 @@ impl Display for Fix<'_> {
                 writeln!(
                     f,
                     "rewrite lockstep file {} from generated",
-                    generated.spec_file_name().path()
+                    generated.doc_file_name().path()
                 )?;
             }
             Fix::UpdateVersionedFiles { old, generated } => {
@@ -763,7 +763,7 @@ impl Display for Fix<'_> {
                 writeln!(
                     f,
                     "write new file {} from generated",
-                    generated.spec_file_name().path()
+                    generated.doc_file_name().path()
                 )?;
             }
             Fix::UpdateExtraFile { path, check_stale } => {
@@ -784,14 +784,14 @@ impl Display for Fix<'_> {
                 writeln!(
                     f,
                     "convert {} to Git stub",
-                    local_file.spec_file_name().path()
+                    local_file.doc_file_name().path()
                 )?;
             }
             Fix::ConvertToJson { local_file, .. } => {
                 writeln!(
                     f,
                     "convert {} from Git stub to JSON",
-                    local_file.spec_file_name().path()
+                    local_file.doc_file_name().path()
                 )?;
             }
             Fix::RegenerateFromBlessed { local_file, git_stub, .. } => {
@@ -799,13 +799,13 @@ impl Display for Fix<'_> {
                     writeln!(
                         f,
                         "regenerate {} from blessed content as Git stub",
-                        local_file.spec_file_name().path()
+                        local_file.doc_file_name().path()
                     )?;
                 } else {
                     writeln!(
                         f,
                         "regenerate {} from blessed content",
-                        local_file.spec_file_name().path()
+                        local_file.doc_file_name().path()
                     )?;
                 }
             }
@@ -814,13 +814,13 @@ impl Display for Fix<'_> {
                     writeln!(
                         f,
                         "restore {} from blessed content as Git stub",
-                        blessed.versioned_spec_file_name().to_git_stub().path()
+                        blessed.versioned_doc_file_name().to_git_stub().path()
                     )?;
                 } else {
                     writeln!(
                         f,
                         "restore {} from blessed content",
-                        blessed.versioned_spec_file_name().path()
+                        blessed.versioned_doc_file_name().path()
                     )?;
                 }
             }
@@ -828,7 +828,7 @@ impl Display for Fix<'_> {
                 writeln!(
                     f,
                     "update Git stub {} to commit {}",
-                    local_file.spec_file_name().path(),
+                    local_file.doc_file_name().path(),
                     git_stub.commit(),
                 )?;
             }
@@ -848,10 +848,10 @@ impl Fix<'_> {
         match self {
             Fix::DeleteFiles { .. } => {}
             Fix::UpdateLockstepFile { generated } => {
-                paths.insert(generated.spec_file_name().path().to_owned());
+                paths.insert(generated.doc_file_name().path().to_owned());
             }
             Fix::UpdateVersionedFiles { generated, .. } => {
-                paths.insert(generated.spec_file_name().path().to_owned());
+                paths.insert(generated.doc_file_name().path().to_owned());
             }
             Fix::UpdateExtraFile { path, .. } => {
                 paths.insert((*path).to_owned());
@@ -860,13 +860,13 @@ impl Fix<'_> {
             Fix::ConvertToGitStub { local_file, .. } => {
                 // Writes to the .gitstub path, not the JSON path.
                 paths.insert(
-                    local_file.spec_file_name().to_git_stub_filename().path(),
+                    local_file.doc_file_name().to_git_stub_filename().path(),
                 );
             }
             Fix::ConvertToJson { local_file, .. } => {
                 // Writes to the JSON path.
                 paths.insert(
-                    local_file.spec_file_name().to_json_filename().path(),
+                    local_file.doc_file_name().to_json_filename().path(),
                 );
             }
             Fix::RegenerateFromBlessed { local_file, git_stub, .. } => {
@@ -874,29 +874,29 @@ impl Fix<'_> {
                     // Writes to a .gitstub file.
                     paths.insert(
                         local_file
-                            .spec_file_name()
+                            .doc_file_name()
                             .to_git_stub_filename()
                             .path(),
                     );
                 } else {
                     // Overwrites the corrupted local file.
-                    paths.insert(local_file.spec_file_name().path().to_owned());
+                    paths.insert(local_file.doc_file_name().path().to_owned());
                 }
             }
             Fix::RestoreFromBlessed { blessed, git_stub } => {
                 if git_stub.is_some() {
                     paths.insert(
-                        blessed.versioned_spec_file_name().to_git_stub().path(),
+                        blessed.versioned_doc_file_name().to_git_stub().path(),
                     );
                 } else {
                     paths.insert(
-                        blessed.versioned_spec_file_name().path().to_owned(),
+                        blessed.versioned_doc_file_name().path().to_owned(),
                     );
                 }
             }
             Fix::UpdateGitStub { local_file, .. } => {
                 // Overwrites the existing .gitstub file in place.
-                paths.insert(local_file.spec_file_name().path().to_owned());
+                paths.insert(local_file.doc_file_name().path().to_owned());
             }
             Fix::DeleteUnparseableFile { .. } => {}
         }
@@ -917,7 +917,7 @@ impl Fix<'_> {
                 Ok(rv)
             }
             Fix::UpdateLockstepFile { generated } => {
-                let path = root.join(generated.spec_file_name().path());
+                let path = root.join(generated.doc_file_name().path());
                 Ok(vec![format!(
                     "updated {}: {:?}",
                     &path,
@@ -932,7 +932,7 @@ impl Fix<'_> {
                     rv.push(format!("removed {}", path));
                 }
 
-                let path = root.join(generated.spec_file_name().path());
+                let path = root.join(generated.doc_file_name().path());
                 rv.push(format!(
                     "created {}: {:?}",
                     path,
@@ -974,10 +974,10 @@ impl Fix<'_> {
                 Ok(vec![format!("wrote link {} -> {}", path, target)])
             }
             Fix::ConvertToGitStub { local_file, git_stub } => {
-                let json_path = root.join(local_file.spec_file_name().path());
+                let json_path = root.join(local_file.doc_file_name().path());
 
                 let git_stub_basename =
-                    local_file.spec_file_name().git_stub_basename();
+                    local_file.doc_file_name().git_stub_basename();
                 let git_stub_path = json_path
                     .parent()
                     .ok_or_else(|| anyhow!("cannot get parent directory"))?
@@ -1003,13 +1003,13 @@ impl Fix<'_> {
             }
             Fix::ConvertToJson { local_file, blessed } => {
                 let git_stub_path =
-                    root.join(local_file.spec_file_name().path());
+                    root.join(local_file.doc_file_name().path());
 
                 // Use the blessed file's contents since it's guaranteed to be
                 // valid.
                 let contents = blessed.contents();
 
-                let json_basename = local_file.spec_file_name().json_basename();
+                let json_basename = local_file.doc_file_name().json_basename();
                 let json_path = git_stub_path
                     .parent()
                     .ok_or_else(|| anyhow!("cannot get parent directory"))?
@@ -1028,7 +1028,7 @@ impl Fix<'_> {
                 ])
             }
             Fix::RegenerateFromBlessed { local_file, blessed, git_stub } => {
-                let local_path = root.join(local_file.spec_file_name().path());
+                let local_path = root.join(local_file.doc_file_name().path());
 
                 // Remove the corrupted file.
                 match fs_err::remove_file(&local_path) {
@@ -1040,7 +1040,7 @@ impl Fix<'_> {
                 if let Some(git_stub) = git_stub {
                     // Write as a Git stub.
                     let git_stub_basename =
-                        local_file.spec_file_name().git_stub_basename();
+                        local_file.doc_file_name().git_stub_basename();
                     let git_stub_path = local_path
                         .parent()
                         .ok_or_else(|| anyhow!("cannot get parent directory"))?
@@ -1072,7 +1072,7 @@ impl Fix<'_> {
             Fix::RestoreFromBlessed { blessed, git_stub } => {
                 if let Some(git_stub) = git_stub {
                     let git_stub_path = root.join(
-                        blessed.versioned_spec_file_name().to_git_stub().path(),
+                        blessed.versioned_doc_file_name().to_git_stub().path(),
                     );
                     let overwrite_status = overwrite_file(
                         &git_stub_path,
@@ -1084,7 +1084,7 @@ impl Fix<'_> {
                     )])
                 } else {
                     let path =
-                        root.join(blessed.versioned_spec_file_name().path());
+                        root.join(blessed.versioned_doc_file_name().path());
                     let overwrite_status =
                         overwrite_file(&path, blessed.contents())?;
                     Ok(vec![format!(
@@ -1095,7 +1095,7 @@ impl Fix<'_> {
             }
             Fix::UpdateGitStub { local_file, git_stub } => {
                 let git_stub_path =
-                    root.join(local_file.spec_file_name().path());
+                    root.join(local_file.doc_file_name().path());
                 let overwrite_status = overwrite_file(
                     &git_stub_path,
                     git_stub.to_file_contents().as_bytes(),
@@ -1185,15 +1185,15 @@ impl<'a> Resolved<'a> {
             ApiIdent,
             Option<semver::Version>,
             NonVersionProblem<'_>,
-        )> = resolve_orphaned_local_specs(&supported_versions_by_api, local)
-            .map(|spec_file_name| {
-                let ident = spec_file_name.ident().clone();
-                let version = Some(spec_file_name.version().clone());
+        )> = resolve_orphaned_local_docs(&supported_versions_by_api, local)
+            .map(|doc_file_name| {
+                let ident = doc_file_name.ident().clone();
+                let version = Some(doc_file_name.version().clone());
                 (
                     ident,
                     version,
-                    NonVersionProblem::LocalSpecFileOrphaned {
-                        spec_file_name: spec_file_name.clone(),
+                    NonVersionProblem::LocalDocFileOrphaned {
+                        doc_file_name: doc_file_name.clone(),
                     },
                 )
             })
@@ -1428,7 +1428,7 @@ fn resolve_removed_blessed_versions<'a>(
     })
 }
 
-fn resolve_orphaned_local_specs<'a>(
+fn resolve_orphaned_local_docs<'a>(
     supported_versions_by_api: &'a BTreeMap<
         &'a ApiIdent,
         BTreeSet<&'a semver::Version>,
@@ -1445,7 +1445,7 @@ fn resolve_orphaned_local_specs<'a>(
             .filter_map(move |(version, files)| match set {
                 Some(set) if !set.contains(version) => {
                     Some(files.iter().map(|f| {
-                        f.spec_file_name()
+                        f.doc_file_name()
                             .as_versioned()
                             .expect("orphaned specs are versioned")
                     }))
@@ -1463,9 +1463,9 @@ fn resolve_api<'a>(
     validation: Option<&DynValidationFn>,
     use_git_stub_storage: bool,
     all_blessed: &'a BlessedFiles,
-    api_blessed: Option<&'a ApiFiles<BlessedApiSpecFile>>,
-    api_generated: &'a ApiFiles<GeneratedApiSpecFile>,
-    api_local: Option<&'a ApiFiles<Vec<LocalApiSpecFile>>>,
+    api_blessed: Option<&'a ApiFiles<BlessedApiDocFile>>,
+    api_generated: &'a ApiFiles<GeneratedApiDocFile>,
+    api_local: Option<&'a ApiFiles<Vec<LocalApiDocFile>>>,
 ) -> ApiResolved<'a> {
     let (by_version, symlink) = if api.is_lockstep() {
         (
@@ -1508,11 +1508,11 @@ fn resolve_api<'a>(
                             // version.
                             let blessed_file = api_blessed
                                 .and_then(|b| b.versions().get(latest_version));
-                            let spec_file_name = blessed_file
-                                .map(|f| f.versioned_spec_file_name().clone());
+                            let doc_file_name = blessed_file
+                                .map(|f| f.versioned_doc_file_name().clone());
                             (
                                 LatestFirstCommit::BlessedError,
-                                Some((spec_file_name, error)),
+                                Some((doc_file_name, error)),
                             )
                         }
                     },
@@ -1580,11 +1580,11 @@ fn resolve_api<'a>(
 
         // If there was an error computing the first commit for the latest
         // version, add the error to the latest version's resolution.
-        if let Some((Some(spec_file_name), error)) = latest_first_commit_error
+        if let Some((Some(doc_file_name), error)) = latest_first_commit_error
             && let Some(resolution) = by_version.get_mut(latest_version)
         {
             resolution.add_problem(VersionProblem::GitStubFirstCommitUnknown {
-                spec_file_name,
+                doc_file_name,
                 source: error,
             });
         }
@@ -1683,7 +1683,7 @@ fn resolve_api<'a>(
                                 });
                             Some(NonVersionProblem::LatestLinkStale {
                                 api_ident: api.ident().clone(),
-                                link: blessed.versioned_spec_file_name(),
+                                link: blessed.versioned_doc_file_name(),
                                 found: latest_local,
                             })
                         }
@@ -1727,7 +1727,7 @@ fn resolve_api<'a>(
                             });
                         Some(NonVersionProblem::LatestLinkMissing {
                             api_ident: api.ident().clone(),
-                            link: blessed.versioned_spec_file_name(),
+                            link: blessed.versioned_doc_file_name(),
                         })
                     }
                     ResolutionKind::NewLocally => {
@@ -1752,8 +1752,8 @@ fn resolve_api_lockstep<'a>(
     env: &'a ResolvedEnv,
     api: &'a ManagedApi,
     validation: Option<&DynValidationFn>,
-    api_generated: &'a ApiFiles<GeneratedApiSpecFile>,
-    api_local: Option<&'a ApiFiles<Vec<LocalApiSpecFile>>>,
+    api_generated: &'a ApiFiles<GeneratedApiDocFile>,
+    api_local: Option<&'a ApiFiles<Vec<LocalApiDocFile>>>,
 ) -> BTreeMap<semver::Version, Resolution<'a>> {
     assert!(api.is_lockstep());
 
@@ -1838,10 +1838,10 @@ fn resolve_api_version<'a>(
     validation: Option<&DynValidationFn>,
     use_git_stub_storage: bool,
     version: ApiVersion<'_>,
-    blessed: Option<&'a BlessedApiSpecFile>,
+    blessed: Option<&'a BlessedApiDocFile>,
     git_stub: Option<&'a BlessedGitStub>,
-    generated: &'a GeneratedApiSpecFile,
-    local: &'a [LocalApiSpecFile],
+    generated: &'a GeneratedApiDocFile,
+    local: &'a [LocalApiDocFile],
     latest_first_commit: LatestFirstCommit,
     merge_base: Option<GitCommitHash>,
 ) -> Resolution<'a> {
@@ -1872,10 +1872,10 @@ fn resolve_api_version_blessed<'a>(
     validation: Option<&DynValidationFn>,
     use_git_stub_storage: bool,
     version: ApiVersion<'_>,
-    blessed: &'a BlessedApiSpecFile,
+    blessed: &'a BlessedApiDocFile,
     git_stub: Option<&'a BlessedGitStub>,
-    generated: &'a GeneratedApiSpecFile,
-    local: &'a [LocalApiSpecFile],
+    generated: &'a GeneratedApiDocFile,
+    local: &'a [LocalApiDocFile],
     latest_first_commit: LatestFirstCommit,
     merge_base: Option<GitCommitHash>,
 ) -> Resolution<'a> {
@@ -1933,7 +1933,7 @@ fn resolve_api_version_blessed<'a>(
     // 2. Unparseable files with matching hash -> corrupted (need regeneration)
     // 3. Everything else -> non-matching
     let blessed_hash = blessed
-        .spec_file_name()
+        .doc_file_name()
         .hash()
         .expect("this should be a versioned file so it should have a hash");
 
@@ -1943,7 +1943,7 @@ fn resolve_api_version_blessed<'a>(
 
     for local_file in local {
         let local_hash = local_file
-            .spec_file_name()
+            .doc_file_name()
             .hash()
             .expect("this should be a versioned file so it should have a hash");
         let hashes_match = local_hash == blessed_hash;
@@ -1989,8 +1989,8 @@ fn resolve_api_version_blessed<'a>(
                         Err(error) => {
                             problems.push(
                                 VersionProblem::GitStubFirstCommitUnknown {
-                                    spec_file_name: blessed
-                                        .versioned_spec_file_name()
+                                    doc_file_name: blessed
+                                        .versioned_doc_file_name()
                                         .clone(),
                                     source: error,
                                 },
@@ -2054,7 +2054,7 @@ fn resolve_api_version_blessed<'a>(
             // version. Mark the redundant file (always the gitstub file in this
             // case) for deletion.
             for local_file in matching {
-                if local_file.spec_file_name().is_git_stub() {
+                if local_file.doc_file_name().is_git_stub() {
                     problems.push(VersionProblem::DuplicateLocalFile {
                         local_file,
                     });
@@ -2062,7 +2062,7 @@ fn resolve_api_version_blessed<'a>(
             }
         } else {
             let local_file = matching[0];
-            if local_file.spec_file_name().is_git_stub() {
+            if local_file.doc_file_name().is_git_stub() {
                 problems.push(VersionProblem::GitStubShouldBeJson {
                     local_file,
                     blessed,
@@ -2094,7 +2094,7 @@ fn resolve_api_version_blessed<'a>(
         // compared to what the blessed source expects. This is shared
         // between the single-match and duplicate-files branches below.
         let check_git_stub_staleness =
-            |local_file: &'a LocalApiSpecFile,
+            |local_file: &'a LocalApiDocFile,
              expected_git_stub: &GitStub,
              problems: &mut Vec<VersionProblem<'a>>| {
                 // Non-gitstub files (JSON) don't have a commit to check.
@@ -2119,7 +2119,7 @@ fn resolve_api_version_blessed<'a>(
             for local_file in matching {
                 match (
                     &storage_format,
-                    local_file.spec_file_name().is_git_stub(),
+                    local_file.doc_file_name().is_git_stub(),
                 ) {
                     // Should be Git stub but have JSON, or should be JSON but
                     // have Git stub: this file is redundant.
@@ -2148,7 +2148,7 @@ fn resolve_api_version_blessed<'a>(
         } else {
             let local_file = matching[0];
 
-            match (&storage_format, local_file.spec_file_name().is_git_stub()) {
+            match (&storage_format, local_file.doc_file_name().is_git_stub()) {
                 (VersionStorageFormat::GitStub(git_stub), false) => {
                     // Should be Git stub but is JSON: convert to Git stub.
                     problems.push(
@@ -2186,9 +2186,9 @@ fn resolve_api_version_blessed<'a>(
 
     // Report non-matching local files as extra.
     problems.extend(non_matching.into_iter().map(|s| {
-        VersionProblem::BlessedVersionExtraLocalSpec {
-            spec_file_name: s
-                .spec_file_name()
+        VersionProblem::BlessedVersionExtraLocalDoc {
+            doc_file_name: s
+                .doc_file_name()
                 .as_versioned()
                 .expect("blessed extra spec is versioned")
                 .clone(),
@@ -2203,8 +2203,8 @@ fn resolve_api_version_local<'a>(
     api: &'_ ManagedApi,
     validation: Option<&DynValidationFn>,
     version: ApiVersion<'_>,
-    generated: &'a GeneratedApiSpecFile,
-    local: &'a [LocalApiSpecFile],
+    generated: &'a GeneratedApiDocFile,
+    local: &'a [LocalApiDocFile],
 ) -> Resolution<'a> {
     let mut problems = Vec::new();
 
@@ -2224,25 +2224,25 @@ fn resolve_api_version_local<'a>(
         } else {
             // There were non-matching specs.  This is your basic "stale" case.
             problems.push(VersionProblem::LocalVersionStale {
-                spec_files: non_matching,
+                doc_files: non_matching,
                 generated,
             });
         }
     } else if !non_matching.is_empty() {
         // There was a matching spec, but also some non-matching ones.
         // These are superfluous.  (It's not clear how this could happen.)
-        let spec_file_names = DisplayableVec(
+        let doc_file_names = DisplayableVec(
             non_matching
                 .iter()
                 .map(|s| {
-                    s.spec_file_name()
+                    s.doc_file_name()
                         .as_versioned()
                         .expect("local specs in versioned API are versioned")
                         .clone()
                 })
                 .collect(),
         );
-        problems.push(VersionProblem::LocalVersionExtra { spec_file_names });
+        problems.push(VersionProblem::LocalVersionExtra { doc_file_names });
     }
 
     Resolution::new_new_locally(problems)
@@ -2253,7 +2253,7 @@ fn validate_generated(
     api: &ManagedApi,
     validation: Option<&DynValidationFn>,
     version: ApiVersion<'_>,
-    generated: &GeneratedApiSpecFile,
+    generated: &GeneratedApiDocFile,
     problems: &mut Vec<VersionProblem<'_>>,
 ) {
     match validate(

--- a/crates/dropshot-api-manager/src/validation.rs
+++ b/crates/dropshot-api-manager/src/validation.rs
@@ -1,8 +1,8 @@
 // Copyright 2026 Oxide Computer Company
 
 use crate::{
-    apis::ManagedApi, environment::ResolvedEnv,
-    spec_files_generated::GeneratedApiSpecFile,
+    apis::ManagedApi, doc_files_generated::GeneratedApiDocFile,
+    environment::ResolvedEnv,
 };
 use anyhow::Context;
 use atomicwrites::AtomicFile;
@@ -24,13 +24,13 @@ pub fn validate(
     is_latest: bool,
     is_blessed: Option<bool>,
     validation: Option<&DynValidationFn>,
-    generated: &GeneratedApiSpecFile,
+    generated: &GeneratedApiDocFile,
 ) -> anyhow::Result<Vec<(Utf8PathBuf, CheckStatus)>> {
     let openapi = generated.openapi();
     let validation_result = validate_generated_openapi_document(
         api,
         openapi,
-        generated.spec_file_name(),
+        generated.doc_file_name(),
         is_latest,
         is_blessed,
         validation,

--- a/crates/integration-tests/src/fixtures.rs
+++ b/crates/integration-tests/src/fixtures.rs
@@ -1797,7 +1797,7 @@ fn record_validation_call(
     });
 }
 
-fn validate(_spec: &openapiv3::OpenAPI, cx: ValidationContext<'_>) {
+fn validate(_doc: &openapiv3::OpenAPI, cx: ValidationContext<'_>) {
     // Only used with versioned APIs, so version is always present.
     let version = cx
         .file_name()
@@ -1809,7 +1809,7 @@ fn validate(_spec: &openapiv3::OpenAPI, cx: ValidationContext<'_>) {
 }
 
 fn validate_with_extra_file(
-    _spec: &openapiv3::OpenAPI,
+    _doc: &openapiv3::OpenAPI,
     mut cx: ValidationContext<'_>,
 ) {
     // Only used with versioned APIs, so version is always present.

--- a/crates/integration-tests/tests/integration/git_stub.rs
+++ b/crates/integration-tests/tests/integration/git_stub.rs
@@ -3288,7 +3288,7 @@ fn test_rebase_blessed_version_missing_local_git_stub() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -3324,7 +3324,7 @@ fn test_merge_blessed_version_missing_local_git_stub() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -3366,7 +3366,7 @@ fn test_jj_rebase_blessed_version_missing_local_git_stub() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -3407,7 +3407,7 @@ fn test_jj_merge_blessed_version_missing_local_git_stub() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -106,30 +106,30 @@ fn test_versioned_content_by_version() -> Result<()> {
     // Parse all version documents.
     let v1_content =
         env.read_versioned_document("versioned-health", "1.0.0")?;
-    let v1_spec: OpenAPI = serde_json::from_str(&v1_content)?;
+    let v1_doc: OpenAPI = serde_json::from_str(&v1_content)?;
 
     let v2_content =
         env.read_versioned_document("versioned-health", "2.0.0")?;
-    let v2_spec: OpenAPI = serde_json::from_str(&v2_content)?;
+    let v2_doc: OpenAPI = serde_json::from_str(&v2_content)?;
 
     let v3_content =
         env.read_versioned_document("versioned-health", "3.0.0")?;
-    let v3_spec: OpenAPI = serde_json::from_str(&v3_content)?;
+    let v3_doc: OpenAPI = serde_json::from_str(&v3_content)?;
 
     // Version 1.0.0 should only have /health endpoint.
-    assert!(v1_spec.paths.paths.contains_key("/health"));
-    assert!(!v1_spec.paths.paths.contains_key("/health/detailed"));
-    assert!(!v1_spec.paths.paths.contains_key("/metrics"));
+    assert!(v1_doc.paths.paths.contains_key("/health"));
+    assert!(!v1_doc.paths.paths.contains_key("/health/detailed"));
+    assert!(!v1_doc.paths.paths.contains_key("/metrics"));
 
     // Version 2.0.0 should have /health and /health/detailed endpoints.
-    assert!(v2_spec.paths.paths.contains_key("/health"));
-    assert!(v2_spec.paths.paths.contains_key("/health/detailed"));
-    assert!(!v2_spec.paths.paths.contains_key("/metrics"));
+    assert!(v2_doc.paths.paths.contains_key("/health"));
+    assert!(v2_doc.paths.paths.contains_key("/health/detailed"));
+    assert!(!v2_doc.paths.paths.contains_key("/metrics"));
 
     // Version 3.0.0 should have all endpoints.
-    assert!(v3_spec.paths.paths.contains_key("/health"));
-    assert!(v3_spec.paths.paths.contains_key("/health/detailed"));
-    assert!(v3_spec.paths.paths.contains_key("/metrics"));
+    assert!(v3_doc.paths.paths.contains_key("/health"));
+    assert!(v3_doc.paths.paths.contains_key("/health/detailed"));
+    assert!(v3_doc.paths.paths.contains_key("/metrics"));
 
     Ok(())
 }
@@ -149,17 +149,17 @@ fn test_versioned_latest_document() -> Result<()> {
     let v3_content =
         env.read_versioned_document("versioned-health", "3.0.0")?;
 
-    let latest_spec: OpenAPI = serde_json::from_str(&latest_content)?;
-    let v3_spec: OpenAPI = serde_json::from_str(&v3_content)?;
+    let latest_doc: OpenAPI = serde_json::from_str(&latest_content)?;
+    let v3_doc: OpenAPI = serde_json::from_str(&v3_content)?;
 
     // Latest should match version 3.0.0 (newest version).
-    assert_eq!(latest_spec.info.version, "3.0.0");
-    assert_eq!(latest_spec.paths.paths.len(), v3_spec.paths.paths.len());
+    assert_eq!(latest_doc.info.version, "3.0.0");
+    assert_eq!(latest_doc.paths.paths.len(), v3_doc.paths.paths.len());
 
     // Both should have all endpoints.
-    assert!(latest_spec.paths.paths.contains_key("/health"));
-    assert!(latest_spec.paths.paths.contains_key("/health/detailed"));
-    assert!(latest_spec.paths.paths.contains_key("/metrics"));
+    assert!(latest_doc.paths.paths.contains_key("/health"));
+    assert!(latest_doc.paths.paths.contains_key("/health/detailed"));
+    assert!(latest_doc.paths.paths.contains_key("/metrics"));
 
     Ok(())
 }
@@ -592,7 +592,7 @@ fn test_removing_api_version_fails_check() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::LocalSpecFileOrphaned,
+                ProblemKind::LocalDocFileOrphaned,
             ),
             ProblemSummary::for_api(
                 "versioned-health",
@@ -704,7 +704,7 @@ fn test_retiring_latest_blessed_version() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::LocalSpecFileOrphaned,
+                ProblemKind::LocalDocFileOrphaned,
             ),
             ProblemSummary::for_api(
                 "versioned-health",
@@ -746,8 +746,8 @@ fn test_retiring_latest_blessed_version() -> Result<()> {
     // Verify the latest document now points to v2.0.0 (the new highest version).
     let latest_content =
         env.read_versioned_latest_document("versioned-health")?;
-    let latest_spec: OpenAPI = serde_json::from_str(&latest_content)?;
-    assert_eq!(latest_spec.info.version, "2.0.0");
+    let latest_doc: OpenAPI = serde_json::from_str(&latest_content)?;
+    assert_eq!(latest_doc.info.version, "2.0.0");
 
     // Commit the retired version.
     env.commit_documents()?;
@@ -778,8 +778,8 @@ fn test_retiring_latest_blessed_version() -> Result<()> {
     // should be the blessed version, not the generated version.
     let latest_content =
         env.read_versioned_latest_document("versioned-health")?;
-    let latest_spec: OpenAPI = serde_json::from_str(&latest_content)?;
-    assert_eq!(latest_spec.info.version, "2.0.0");
+    let latest_doc: OpenAPI = serde_json::from_str(&latest_content)?;
+    assert_eq!(latest_doc.info.version, "2.0.0");
 
     // Verify we can no longer use the old full API against the new blessed
     // documents.
@@ -856,7 +856,7 @@ fn test_retiring_older_blessed_version() -> Result<()> {
         [ProblemSummary::new(
             "versioned-health",
             "2.0.0",
-            ProblemKind::LocalSpecFileOrphaned,
+            ProblemKind::LocalDocFileOrphaned,
         )],
     );
 
@@ -893,8 +893,8 @@ fn test_retiring_older_blessed_version() -> Result<()> {
     // Verify the latest document still points to v3.0.0 (the highest version).
     let latest_content =
         env.read_versioned_latest_document("versioned-health")?;
-    let latest_spec: OpenAPI = serde_json::from_str(&latest_content)?;
-    assert_eq!(latest_spec.info.version, "3.0.0");
+    let latest_doc: OpenAPI = serde_json::from_str(&latest_content)?;
+    assert_eq!(latest_doc.info.version, "3.0.0");
 
     // Commit the retired version.
     env.commit_documents()?;
@@ -925,8 +925,8 @@ fn test_retiring_older_blessed_version() -> Result<()> {
     // should be the blessed version, not the generated version.
     let latest_content =
         env.read_versioned_latest_document("versioned-health")?;
-    let latest_spec: OpenAPI = serde_json::from_str(&latest_content)?;
-    assert_eq!(latest_spec.info.version, "3.0.0");
+    let latest_doc: OpenAPI = serde_json::from_str(&latest_content)?;
+    assert_eq!(latest_doc.info.version, "3.0.0");
 
     // Verify we can no longer use the old full API against the new blessed
     // documents.
@@ -1084,7 +1084,7 @@ fn test_incompatible_blessed_api_change() -> Result<()> {
     Ok(())
 }
 
-/// Test BlessedVersionExtraLocalSpec problems.
+/// Test BlessedVersionExtraLocalDoc problems.
 ///
 /// This test:
 ///
@@ -1092,7 +1092,7 @@ fn test_incompatible_blessed_api_change() -> Result<()> {
 /// * in a separate environment, creates another blessed version
 /// * copies over this extra version
 #[test]
-fn test_blessed_version_extra_local_spec() -> Result<()> {
+fn test_blessed_version_extra_local_doc() -> Result<()> {
     let env = TestEnvironment::new_git()?;
     let apis = versioned_health_apis()?;
 
@@ -1141,7 +1141,7 @@ fn test_blessed_version_extra_local_spec() -> Result<()> {
         [ProblemSummary::new(
             "versioned-health",
             "3.0.0",
-            ProblemKind::BlessedVersionExtraLocalSpec,
+            ProblemKind::BlessedVersionExtraLocalDoc,
         )],
     );
 
@@ -1779,7 +1779,7 @@ fn test_rebase_blessed_version_missing_local() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -1815,7 +1815,7 @@ fn test_merge_blessed_version_missing_local() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -1857,7 +1857,7 @@ fn test_jj_rebase_blessed_version_missing_local() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -1898,7 +1898,7 @@ fn test_jj_merge_blessed_version_missing_local() -> Result<()> {
             ProblemSummary::new(
                 "versioned-health",
                 "3.0.0",
-                ProblemKind::BlessedVersionExtraLocalSpec,
+                ProblemKind::BlessedVersionExtraLocalDoc,
             ),
         ],
     );
@@ -1933,11 +1933,11 @@ fn test_blessed_ws_old_format_fails_without_normalizer() -> Result<()> {
         .expect("v1 doc should exist");
     let new_content = env.read_file(&new_doc_path)?;
 
-    let old_spec: serde_json::Value = serde_json::from_str(&old_content)?;
-    let new_spec: serde_json::Value = serde_json::from_str(&new_content)?;
+    let old_doc: serde_json::Value = serde_json::from_str(&old_content)?;
+    let new_doc: serde_json::Value = serde_json::from_str(&new_content)?;
 
     // Raw drift comparison (no normalizer) should find issues.
-    let changes = drift::compare(&old_spec, &new_spec)?;
+    let changes = drift::compare(&old_doc, &new_doc)?;
     let non_trivial: Vec<_> = changes
         .iter()
         .filter(|c| {


### PR DESCRIPTION
Consistently say "OpenAPI document" rather than "OpenAPI spec".
