### PR TITLE
[dropshot-api-manager] say document, not spec, in strings and comments

### DIFF
--- a/crates/dropshot-api-manager/src/cmd/debug.rs
+++ b/crates/dropshot-api-manager/src/cmd/debug.rs
@@ -54,7 +54,7 @@ pub(crate) fn debug_impl(
     dump_structure(&generated, &errors);
 
     // Print result of resolving the differences.
-    println!("Resolving specs");
+    println!("Resolving documents");
     let resolved = Resolved::new(env, apis, &blessed, &generated, &local_files);
     for note in resolved.notes() {
         println!("NOTE: {}", note);

--- a/crates/dropshot-api-manager/src/cmd/list.rs
+++ b/crates/dropshot-api-manager/src/cmd/list.rs
@@ -94,7 +94,7 @@ pub(crate) fn list_impl(
             writeln!(
                 &mut out,
                 "{initial_indent} {}:",
-                "spec details".style(styles.header),
+                "document details".style(styles.header),
             )?;
 
             for v in api.iter_versions_semver() {

--- a/crates/dropshot-api-manager/src/compatibility/detect.rs
+++ b/crates/dropshot-api-manager/src/compatibility/detect.rs
@@ -294,8 +294,8 @@ fn escape_json_pointer(s: &str) -> String {
     s.replace('~', "~0").replace('/', "~1")
 }
 
-/// Normalize old-format websocket responses in the blessed spec to match the
-/// new format used by the generated spec.
+/// Normalize old-format websocket responses in the blessed document to match
+/// the new format used by the generated document.
 ///
 /// Dropshot 0.17 changed how websocket endpoints are represented in OpenAPI
 /// (see https://github.com/oxidecomputer/dropshot/pull/1554):
@@ -318,9 +318,9 @@ fn escape_json_pointer(s: &str) -> String {
 ///
 /// This function detects operations with the `x-dropshot-websocket` extension
 /// that still have the old response format and replaces their responses with
-/// those from the corresponding operation in the generated spec. This is safe
-/// because the wire format did not change — only the OpenAPI representation
-/// did.
+/// those from the corresponding operation in the generated document. This is
+/// safe because the wire format did not change — only the OpenAPI
+/// representation did.
 fn normalize_old_websocket_responses(
     blessed: &mut serde_json::Value,
     generated: &serde_json::Value,
@@ -394,14 +394,14 @@ pub(crate) fn api_compatible(
 ) -> anyhow::Result<Vec<ApiCompatIssue>> {
     let mut blessed = blessed.clone();
 
-    // Normalize old-format websocket responses in the blessed spec before
+    // Normalize old-format websocket responses in the blessed document before
     // comparison. Dropshot 0.17 changed how websocket endpoints are
     // represented: from a `default` response with `*/*` content to explicit
-    // `101`/`4XX`/`5XX` responses. This is purely a spec-generation change,
-    // not a wire-format change.
+    // `101`/`4XX`/`5XX` responses. This is purely a document-generation
+    // change, not a wire-format change.
     normalize_old_websocket_responses(&mut blessed, generated);
 
-    // Build the per-spec op-id maps once. Each issue consults them through
+    // Build the per-document op-id maps once. Each issue consults them through
     // `DocumentBasePath::classify` to populate the `operation_id` field on
     // its endpoint variants.
     let blessed_op_ids = extract_operation_ids(&blessed);
@@ -580,8 +580,8 @@ mod tests {
 
     #[test]
     fn test_normalize_missing_generated_path_leaves_blessed_unchanged() {
-        // If the generated spec doesn't have the websocket path, the blessed
-        // spec should be left unchanged.
+        // If the generated document doesn't have the websocket path, the
+        // blessed document should be left unchanged.
         let mut blessed = serde_json::json!({
             "paths": {
                 "/subscribe": {
@@ -610,8 +610,8 @@ mod tests {
 
     #[test]
     fn test_api_compatible_old_ws_format() {
-        // Old-format blessed spec should be compatible with new-format
-        // generated spec after normalization.
+        // Old-format blessed document should be compatible with new-format
+        // generated document after normalization.
         let blessed = serde_json::json!({
             "openapi": "3.0.3",
             "info": { "title": "Test", "version": "1.0.0" },

--- a/crates/dropshot-api-manager/src/compatibility/display.rs
+++ b/crates/dropshot-api-manager/src/compatibility/display.rs
@@ -717,7 +717,7 @@ mod tests {
 
     /// Build a small [`OperationIdMap`] from `(endpoint_base, op_id)` pairs.
     /// Used by synthetic-issue tests that bypass `api_compatible` and so
-    /// don't have a spec to extract op ids from.
+    /// don't have a document to extract op ids from.
     fn op_ids<'a>(entries: &[(&str, &'a str)]) -> OperationIdMap<'a> {
         entries
             .iter()

--- a/crates/dropshot-api-manager/src/compatibility/types.rs
+++ b/crates/dropshot-api-manager/src/compatibility/types.rs
@@ -138,8 +138,8 @@ pub(super) struct SubpathChange {
 /// This enum classifies base document paths so the rendering layer can pattern
 /// match on the variant rather than asking "is this a component? is this an
 /// endpoint?" each time it inspects a base path. For endpoint variants, the
-/// spec's `operationId` is carried alongside the path so that display code can
-/// annotate it on the rendered endpoint.
+/// document's `operationId` is carried alongside the path so that display code
+/// can annotate it on the rendered endpoint.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(super) enum DocumentBasePath {
     /// A reusable component, e.g., `#/components/schemas/Foo`.
@@ -148,7 +148,7 @@ pub(super) enum DocumentBasePath {
     Endpoint {
         /// The path (`paths/<route>/<method>`).
         name: DocumentPath,
-        /// The endpoint's `operationId` from the spec, if found.
+        /// The endpoint's `operationId` from the document, if found.
         operation_id: Option<String>,
     },
     /// The `.paths` container itself — not a meaningful change location.

--- a/crates/dropshot-api-manager/src/doc_files_blessed.rs
+++ b/crates/dropshot-api-manager/src/doc_files_blessed.rs
@@ -31,7 +31,7 @@ use std::{collections::BTreeMap, ops::Deref};
 /// This type only represents versioned APIs, not lockstep APIs. Lockstep APIs
 /// don't have a meaningful "blessed" source since they're always regenerated.
 /// The type system enforces this invariant: construction will panic if given a
-/// lockstep spec.
+/// lockstep document.
 pub struct BlessedApiDocFile {
     inner: ApiDocFile,
     /// Cached versioned filename, avoiding repeated conversion.
@@ -56,15 +56,15 @@ impl BlessedApiDocFile {
     ///
     /// # Panics
     ///
-    /// Panics if the spec file is for a lockstep API. Blessed files only exist
-    /// for versioned APIs.
+    /// Panics if the document file is for a lockstep API. Blessed files only
+    /// exist for versioned APIs.
     pub fn new(inner: ApiDocFile) -> Self {
         let versioned_name = inner
             .doc_file_name()
             .as_versioned()
             .unwrap_or_else(|| {
                 panic!(
-                    "BlessedApiDocFile requires a versioned API spec, \
+                    "BlessedApiDocFile requires a versioned API document, \
                      got lockstep: {}",
                     inner.doc_file_name()
                 )
@@ -73,7 +73,7 @@ impl BlessedApiDocFile {
         Self { inner, versioned_name }
     }
 
-    /// Returns the versioned spec file name.
+    /// Returns the versioned document file name.
     ///
     /// Unlike `doc_file_name()` which returns `&ApiDocFileName`, this method
     /// returns the more specific `&VersionedApiDocFileName` since blessed

--- a/crates/dropshot-api-manager/src/doc_files_generic.rs
+++ b/crates/dropshot-api-manager/src/doc_files_generic.rs
@@ -195,14 +195,14 @@ pub(crate) enum BadVersionedFileName {
     UnexpectedName { ident: ApiIdent, source: anyhow::Error },
 }
 
-/// Errors that can occur when parsing an API spec file.
+/// Errors that can occur when parsing an API document file.
 #[derive(Debug, Error)]
 enum ApiDocFileParseError {
     #[error("file {path:?}: parsing as JSON")]
     JsonParse { path: Utf8PathBuf, source: serde_json::Error },
     #[error("file {path:?}: parsing OpenAPI document")]
     OpenApiParse { path: Utf8PathBuf, source: serde_json::Error },
-    #[error("file {path:?}: parsing version from generated spec")]
+    #[error("file {path:?}: parsing version from generated document")]
     VersionParse { path: Utf8PathBuf, source: semver::Error },
     #[error(
         "file {path:?}: version in the file ({file_version}) differs from \
@@ -453,7 +453,8 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiDocFilesBuilder<'a, T> {
                 if T::MISCONFIGURATIONS_ALLOWED =>
             {
                 // If the ident is part of unknown_apis, then we don't print a
-                // warning here (it will be printed for the generated spec).
+                // warning here (it will be printed for the generated
+                // document).
                 if !self.apis.unknown_apis().contains(&ident) {
                     let warning = anyhow!(
                         "skipping file {basename:?}: {} \
@@ -887,12 +888,12 @@ impl<T: AsRawFiles> ApiFiles<T> {
     }
 }
 
-/// Trait for types that provide spec file metadata.
+/// Trait for types that provide document file metadata.
 ///
 /// This allows iterating over both valid and unparseable files while still
 /// being able to access their names.
 pub trait DocFileInfo {
-    /// Returns the spec file name.
+    /// Returns the document file name.
     fn doc_file_name(&self) -> &ApiDocFileName;
 
     /// Returns the version from the parsed file, if available.

--- a/crates/dropshot-api-manager/src/doc_files_local.rs
+++ b/crates/dropshot-api-manager/src/doc_files_local.rs
@@ -59,7 +59,7 @@ pub enum LocalApiDocFile {
 }
 
 impl LocalApiDocFile {
-    /// Returns the spec file name.
+    /// Returns the document file name.
     pub fn doc_file_name(&self) -> &ApiDocFileName {
         match self {
             Self::Valid { doc, .. } => doc.doc_file_name(),

--- a/crates/dropshot-api-manager/src/resolved.rs
+++ b/crates/dropshot-api-manager/src/resolved.rs
@@ -59,9 +59,9 @@ where
 pub enum Note {
     /// A previously-supported API version has been removed locally.
     ///
-    /// This is not an error because we do expect to EOL old API specs. There's
-    /// not currently a way for this tool to know if the EOL'ing is correct or
-    /// not, so we at least highlight it to the user.
+    /// This is not an error because we do expect to EOL old API documents.
+    /// There's not currently a way for this tool to know if the EOL'ing is
+    /// correct or not, so we at least highlight it to the user.
     #[error(
         "API {api_ident} version {version}: formerly blessed version has been \
          removed.  This version will no longer be supported!  This will break \
@@ -72,8 +72,8 @@ pub enum Note {
     BlessedVersionRemoved { api_ident: ApiIdent, version: semver::Version },
 }
 
-/// Describes the result of resolving the blessed spec(s), generated spec(s),
-/// and local spec files for a particular API
+/// Describes the result of resolving the blessed document(s), generated
+/// document(s), and local document files for a particular API
 pub struct Resolution<'a> {
     kind: ResolutionKind,
     problems: Vec<VersionProblem<'a>>,
@@ -213,9 +213,9 @@ impl ProblemSummary {
     }
 }
 
-/// Describes a problem resolving the blessed spec(s), generated spec(s), and
-/// local spec files for an API that is *not* tied to a specific supported
-/// version.
+/// Describes a problem resolving the blessed document(s), generated
+/// document(s), and local document files for an API that is *not* tied to a
+/// specific supported version.
 ///
 /// Per-(api, version) problems live in [`VersionProblem`] instead. Splitting
 /// the two means that we can establish at compile time that, e.g., symlinks can
@@ -1124,8 +1124,8 @@ fn symlink_file(target: &str, path: &Utf8Path) -> std::io::Result<()> {
     fs_err::os::windows::fs::symlink_file(target, path)
 }
 
-/// Resolve differences between blessed spec(s), the generated spec, and any
-/// local spec files for a given API
+/// Resolve differences between blessed document(s), the generated document,
+/// and any local document files for a given API
 pub struct Resolved<'a> {
     notes: Vec<Note>,
     /// Non-version problems that aren't attached to a supported (api, version)
@@ -1149,7 +1149,8 @@ impl<'a> Resolved<'a> {
     ) -> Resolved<'a> {
         // First, assemble a list of supported versions for each API, as defined
         // in the Rust list of supported versions.  We'll use this to identify
-        // any blessed spec files or local spec files that don't belong at all.
+        // any blessed document files or local document files that don't belong
+        // at all.
         let supported_versions_by_api: BTreeMap<
             &ApiIdent,
             BTreeSet<&semver::Version>,
@@ -1178,9 +1179,9 @@ impl<'a> Resolved<'a> {
         })
         .collect();
 
-        // Get the other easy case out of the way: if there are any local spec
-        // files for APIs or API versions that aren't supported any more, that's
-        // a (fixable) problem.
+        // Get the other easy case out of the way: if there are any local
+        // document files for APIs or API versions that aren't supported any
+        // more, that's a (fixable) problem.
         let mut orphaned_and_unparseable: Vec<(
             ApiIdent,
             Option<semver::Version>,
@@ -1435,8 +1436,8 @@ fn resolve_orphaned_local_docs<'a>(
     >,
     local: &'a LocalFiles,
 ) -> impl Iterator<Item = &'a VersionedApiDocFileName> + 'a {
-    // Orphaned specs are always versioned: lockstep APIs have exactly one file,
-    // so orphans can't exist for them.
+    // Orphaned documents are always versioned: lockstep APIs have exactly one
+    // file, so orphans can't exist for them.
     local.iter().flat_map(|(ident, api_files)| {
         let set = supported_versions_by_api.get(ident);
         api_files
@@ -1447,7 +1448,7 @@ fn resolve_orphaned_local_docs<'a>(
                     Some(files.iter().map(|f| {
                         f.doc_file_name()
                             .as_versioned()
-                            .expect("orphaned specs are versioned")
+                            .expect("orphaned documents are versioned")
                     }))
                 }
                 _ => None,
@@ -1892,7 +1893,7 @@ fn resolve_api_version_blessed<'a>(
     // know via `is_blessed`, letting them skip validation where appropriate.
     validate_generated(env, api, validation, version, generated, &mut problems);
 
-    // First off, the blessed spec must be a subset of the generated one.
+    // First off, the blessed document must be a subset of the generated one.
     // If not, someone has made an incompatible change to the API
     // *implementation*, such that the implementation no longer faithfully
     // implements this older, supported version.
@@ -1910,7 +1911,7 @@ fn resolve_api_version_blessed<'a>(
     };
 
     // For the latest version, also require bytewise equality. This ensures that
-    // trivial changes don't accumulate invisibly. If the generated spec is
+    // trivial changes don't accumulate invisibly. If the generated document is
     // semantically equivalent but bytewise different, require a version bump.
     //
     // This check can be disabled via `allow_trivial_changes_for_latest()`.
@@ -1925,8 +1926,8 @@ fn resolve_api_version_blessed<'a>(
         });
     }
 
-    // Now, there should be at least one local spec that exactly matches the
-    // blessed one.
+    // Now, there should be at least one local document that exactly matches
+    // the blessed one.
     //
     // We partition local files into three categories:
     // 1. Valid files with matching hash/contents -> matching
@@ -2190,7 +2191,7 @@ fn resolve_api_version_blessed<'a>(
             doc_file_name: s
                 .doc_file_name()
                 .as_versioned()
-                .expect("blessed extra spec is versioned")
+                .expect("blessed extra document is versioned")
                 .clone(),
         }
     }));
@@ -2216,20 +2217,21 @@ fn resolve_api_version_local<'a>(
         .partition(|local| local.contents() == generated.contents());
 
     if matching.is_empty() {
-        // There was no matching spec.
+        // There was no matching document.
         if non_matching.is_empty() {
-            // There were no non-matching specs, either.
+            // There were no non-matching documents, either.
             problems
                 .push(VersionProblem::LocalVersionMissingLocal { generated });
         } else {
-            // There were non-matching specs.  This is your basic "stale" case.
+            // There were non-matching documents.  This is your basic "stale"
+            // case.
             problems.push(VersionProblem::LocalVersionStale {
                 doc_files: non_matching,
                 generated,
             });
         }
     } else if !non_matching.is_empty() {
-        // There was a matching spec, but also some non-matching ones.
+        // There was a matching document, but also some non-matching ones.
         // These are superfluous.  (It's not clear how this could happen.)
         let doc_file_names = DisplayableVec(
             non_matching
@@ -2237,7 +2239,9 @@ fn resolve_api_version_local<'a>(
                 .map(|s| {
                     s.doc_file_name()
                         .as_versioned()
-                        .expect("local specs in versioned API are versioned")
+                        .expect(
+                            "local documents in versioned API are versioned",
+                        )
                         .clone()
                 })
                 .collect(),

--- a/crates/integration-tests/src/fixtures.rs
+++ b/crates/integration-tests/src/fixtures.rs
@@ -946,7 +946,7 @@ pub mod versioned_health_skip_middle {
     };
 }
 
-/// Versioned API with a websocket endpoint, for testing spec format changes
+/// Versioned API with a websocket endpoint, for testing document format changes
 /// across dropshot versions. The websocket response format changed between
 /// dropshot 0.16 and 0.17 (from a `default` response to explicit `101`/`4XX`/
 /// `5XX` responses), and this fixture exercises that scenario.
@@ -1435,7 +1435,7 @@ pub fn create_mixed_test_apis() -> Result<ManagedApis> {
     ManagedApis::new(configs).context("failed to create mixed ManagedApis")
 }
 
-/// Create a versioned websocket API for testing spec format normalization.
+/// Create a versioned websocket API for testing document format normalization.
 pub fn versioned_ws_api() -> ManagedApiConfig {
     ManagedApiConfig {
         ident: "versioned-ws",

--- a/crates/integration-tests/tests/integration/versioned.rs
+++ b/crates/integration-tests/tests/integration/versioned.rs
@@ -1908,16 +1908,16 @@ fn test_jj_merge_blessed_version_missing_local() -> Result<()> {
     blessed_version_missing_local_verify(&env)
 }
 
-// --- Websocket spec format normalization tests ---
+// --- Websocket document format normalization tests ---
 
-/// Verify that without normalization, old-format websocket blessed specs
+/// Verify that without normalization, old-format websocket blessed documents
 /// would be detected as incompatible by drift. This proves the normalizer
 /// is necessary.
 #[test]
 fn test_blessed_ws_old_format_fails_without_normalizer() -> Result<()> {
     let env = TestEnvironment::new_git()?;
 
-    // Generate old-format and new-format v1 specs from their respective
+    // Generate old-format and new-format v1 documents from their respective
     // API traits and compare directly with drift.
     let old_apis = versioned_ws_old_apis()?;
     env.generate_documents(&old_apis)?;
@@ -1962,7 +1962,7 @@ fn test_blessed_ws_old_format_fails_without_normalizer() -> Result<()> {
 /// Test that blessed documents with old websocket response format (pre-0.17
 /// dropshot) are normalized during compatibility checking. Older (non-latest)
 /// blessed versions pass because they use semantic equality. The latest version
-/// still fails because it requires bytewise equality — the normalized spec
+/// still fails because it requires bytewise equality — the normalized document
 /// format differs from the old committed format.
 #[test]
 fn test_blessed_ws_old_format_normalized_older_versions_pass() -> Result<()> {

--- a/e2e-example/bin/src/main.rs
+++ b/e2e-example/bin/src/main.rs
@@ -137,14 +137,14 @@ enum ApiBoundary {
     External,
 }
 
-fn validate(spec: &OpenAPI, mut cx: ValidationContext<'_>) {
+fn validate(doc: &OpenAPI, mut cx: ValidationContext<'_>) {
     // Here, we use Oxide's openapi-lint crate to perform some linting on the
     // OpenAPI document. This kind of validation is optional.
     let extra: ApiExtra =
         serde_json::from_value(cx.metadata().extra.clone()).unwrap();
     let errors = match extra.boundary {
-        ApiBoundary::Internal => openapi_lint::validate(spec),
-        ApiBoundary::External => openapi_lint::validate_external(spec),
+        ApiBoundary::Internal => openapi_lint::validate(doc),
+        ApiBoundary::External => openapi_lint::validate_external(doc),
     };
     for error in errors {
         cx.report_error(anyhow!(error));

--- a/e2e-example/client/build.rs
+++ b/e2e-example/client/build.rs
@@ -12,7 +12,7 @@ fn main() {
     let materializer = Materializer::for_build_script("../..")
         .expect("detected VCS at repo root");
 
-    // Materialize the v1.0.0 API spec from its Git stub.
+    // Materialize the v1.0.0 API document from its Git stub.
     //
     // The .gitstub file contains a reference like:
     //   11ce810ee5...:e2e-example/documents/versioned-git-stub/versioned-git-stub-1.0.0-50a3d4.json
@@ -22,12 +22,12 @@ fn main() {
     // 1. Read the git-stub file.
     // 2. Fetch the content from git (or jj) history.
     // 3. Write it to OUT_DIR/git-stub-vcs/e2e-example/documents/versioned-git-stub/versioned-git-stub-1.0.0-50a3d4.json.
-    let spec_path = materializer
+    let doc_path = materializer
         .materialize(
             "e2e-example/documents/versioned-git-stub/versioned-git-stub-1.0.0-50a3d4.json.gitstub",
         )
         .expect("materialized git-stub file");
 
     // Print the path for debugging purposes.
-    println!("cargo::warning=materialized spec to: {}", spec_path);
+    println!("cargo::warning=materialized document to: {}", doc_path);
 }

--- a/e2e-example/client/src/lib.rs
+++ b/e2e-example/client/src/lib.rs
@@ -11,7 +11,8 @@
 //! 2. The `generate_api!` macro uses `relative_to = OutDir` to read the
 //!    materialized file from `OUT_DIR`.
 
-// Generate a client from the v1.0.0 API spec which is stored as a Git stub.
+// Generate a client from the v1.0.0 API document which is stored as a Git
+// stub.
 // The build script materializes this to OUT_DIR/git-stub-vcs/.
 progenitor::generate_api!(
     spec = {


### PR DESCRIPTION
Sweep user-visible strings, error and expect messages, and comments to
use OpenAPI "document" terminology.
